### PR TITLE
Add task protocol methods for triggers

### DIFF
--- a/lib/protocol/task.js
+++ b/lib/protocol/task.js
@@ -476,5 +476,32 @@ function taskProtocolFactory (Promise, assert, Constants, messenger, _, Result) 
         );
     };
 
+    TaskProtocol.prototype.publishTrigger = function (uuid, type, group) {
+        assert.uuid(uuid, 'routing key uuid suffix');
+        assert.string(type, 'trigger type');
+        assert.string(group, 'trigger group');
+
+        return messenger.publish(
+            Constants.Protocol.Exchanges.Task.Name,
+            'trigger' + '.' + uuid + '.' + group + '.' + type,
+            {}
+        );
+    };
+
+    TaskProtocol.prototype.subscribeTrigger = function (uuid, type, group, callback) {
+        assert.uuid(uuid, 'routing key uuid suffix');
+        assert.string(type, 'trigger type');
+        assert.string(group, 'trigger group');
+        assert.func(callback, 'callback');
+
+        return messenger.subscribe(
+            Constants.Protocol.Exchanges.Task.Name,
+            'trigger' + '.' + uuid + '.' + group + '.' + type,
+            function() {
+                callback();
+            }
+        );
+    };
+
     return new TaskProtocol();
 }

--- a/spec/lib/protocol/task-spec.js
+++ b/spec/lib/protocol/task-spec.js
@@ -753,4 +753,35 @@ describe("Task protocol functions", function() {
         });
     });
 
+    describe("Trigger", function() {
+        var testSubscription;
+
+        afterEach("cancel afterEach", function() {
+            // unsubscribe to clean up after ourselves
+            return testSubscription.dispose();
+        });
+
+        it("should subscribe and receive triggers", function(done) {
+            var self = this,
+                uuid = helper.injector.get('uuid'),
+                triggerGroup = 'testGroup',
+                triggerType = 'testType',
+                testUuid = uuid.v4();
+
+            self.task.subscribeTrigger(testUuid, triggerType, triggerGroup, function() {
+                try {
+                    done();
+                } catch(err) {
+                    done(err);
+                }
+            }).then(function(subscription) {
+                expect(subscription).to.be.ok;
+
+                testSubscription = subscription;
+                return self.task.publishTrigger(testUuid, triggerType, triggerGroup);
+            }).catch(function(err) {
+                done(err);
+            });
+        });
+    });
 });


### PR DESCRIPTION
Supports https://hwjiraprd01.corp.emc.com/browse/MON-421 (Monorail Discovery workflow netbooting should be idempotent) by adding trigger protocol methods (see https://github.com/RackHD/on-tasks/pull/9).
