### PR TITLE
ORFS-80: remove a compute node

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -56,8 +56,9 @@ function constantsFactory (path) {
         },
         WorkItems: {
             Pollers: {
-                IPMI: 'Pollers.IPMI',
-                SNMP: 'Pollers.SNMP',
+                IPMI:   'Pollers.IPMI',
+                SNMP:   'Pollers.SNMP',
+                COMMON: 'Pollers.COMMON',
                 Metrics: {
                     SnmpInterfaceBandwidthUtilization: 'snmp-interface-bandwidth-utilization',
                     SnmpInterfaceState: 'snmp-interface-state',
@@ -156,6 +157,14 @@ function constantsFactory (path) {
                         durable: true,
                         autoDelete: false
                     }
+                },
+                Ltae: {
+                    Name: 'onrack.ltae.internal.critical_alert_0',
+                    Options: {
+                        type: 'topic',
+                        durable: true,
+                        autoDelete: false
+                    }
                 }
             }
         },
@@ -172,6 +181,11 @@ function constantsFactory (path) {
             Cancelled: 'cancelled',
             Timeout: 'timeout',
             Pending: 'pending'
+        },
+        NetworkStates: {
+            Connected    : 'connected',
+            Disconnected : 'disconnected',
+            Unstable     : 'unstable'
         },
         Regex: {
             Base64: /^(?:[A-Z0-9+\/]{4})*(?:[A-Z0-9+\/]{2}==|[A-Z0-9+\/]{3}=|[A-Z0-9+\/]{4})$/i,

--- a/lib/common/messenger.js
+++ b/lib/common/messenger.js
@@ -150,7 +150,6 @@ function messengerFactory(
     Messenger.prototype.publish = function (name, routingKey, data, options) {
         assert.string(name, 'name');
         assert.string(routingKey, 'routingKey');
-        assert.object(data, 'data');
 
         if (_.isUndefined(this.transmit)) {
             return Promise.reject(new Error('Connection Not Established.'));

--- a/lib/protocol/ltae.js
+++ b/lib/protocol/ltae.js
@@ -1,0 +1,52 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+module.exports = ltaeProtocolFactory;
+
+ltaeProtocolFactory.$provide = 'Protocol.Ltae';
+ltaeProtocolFactory.$inject = [
+    'Constants',
+    'Services.Messenger',
+    'Assert'
+];
+
+function ltaeProtocolFactory (
+    Constants,
+    messenger,
+    assert
+) {
+    function LtaeProtocol () {
+    }
+
+    LtaeProtocol.prototype.publishLtae = function (data) {
+        assert.string(data);
+
+        return messenger.publish(
+            Constants.Protocol.Exchanges.Ltae.Name,
+            'lta_to_ltae',
+            data
+        );
+    };
+
+    LtaeProtocol.prototype.makeMessage = function (messageIdName, args) {
+        assert.string(messageIdName);
+        assert.object(args);
+
+        var alerts = {},
+            alertsString = '';
+        /* This message format is defined by OnRack northbound, ignore jshint check here */
+        alerts['messageID']        = 'onrackconductor.0.3.0.' + messageIdName; /*jshint ignore:line*/
+        alerts['bounding_style']   = 'self';        /* jshint ignore:line */
+        alerts['in_condition']     = 'True';        /* jshint ignore:line */
+        alerts['time_created']     = new Date();    /* jshint ignore:line */
+        alerts['version']          = '1.0';         /* jshint ignore:line */
+        alerts['arguments']        = args;          /* jshint ignore:line */
+
+        alertsString = JSON.stringify(alerts);
+
+        return alertsString;
+    };
+
+    return new LtaeProtocol();
+}

--- a/lib/protocol/task.js
+++ b/lib/protocol/task.js
@@ -408,6 +408,58 @@ function taskProtocolFactory (Promise, assert, Constants, messenger, _, Result) 
         );
     };
 
+    TaskProtocol.prototype.publishRunCommonCommand = function (uuid, command, data) {
+        assert.uuid(uuid, 'routing key uuid suffix');
+        assert.string(command);
+        assert.object(data);
+
+        return messenger.publish(
+            Constants.Protocol.Exchanges.Task.Name,
+            'run.common.command' + '.' + uuid + '.' + command,
+            new Result({ value: data })
+        );
+    };
+
+    TaskProtocol.prototype.subscribeRunCommonCommand = function (uuid, command, callback) {
+        assert.uuid(uuid, 'routing key uuid suffix');
+        assert.string(command);
+        assert.func(callback, 'callback');
+
+        return messenger.subscribe(
+            Constants.Protocol.Exchanges.Task.Name,
+            'run.common.command' + '.' + uuid + '.' + command,
+            function(data) {
+                callback(data.value);
+            }
+        );
+    };
+
+    TaskProtocol.prototype.subscribeCommonCommandResult = function (uuid, command, callback) {
+        assert.uuid(uuid, 'routing key uuid suffix');
+        assert.string(command);
+        assert.func(callback, 'callback');
+
+        return messenger.subscribe(
+            Constants.Protocol.Exchanges.Task.Name,
+            ['common', 'command', command, 'result', uuid].join('.'),
+            function(data) {
+                callback(data.value);
+            }
+        );
+    };
+
+    TaskProtocol.prototype.publishCommonCommandResult = function (uuid, command, results) {
+        assert.uuid(uuid, 'routing key uuid suffix');
+        assert.string(command);
+        assert.object(results);
+
+        return messenger.publish(
+            Constants.Protocol.Exchanges.Task.Name,
+            ['common', 'command', command, 'result', uuid].join('.'),
+            new Result({ value: results })
+        );
+    };
+
     // NOTE: publishes onto the events exchange
     TaskProtocol.prototype.publishPollerAlert = function (uuid, results) {
         assert.uuid(uuid, 'routing key uuid suffix');

--- a/spec/lib/protocol/task-spec.js
+++ b/spec/lib/protocol/task-spec.js
@@ -621,6 +621,78 @@ describe("Task protocol functions", function() {
         });
     });
 
+    describe("runCommonCommand", function() {
+
+        var testSubscription;
+        afterEach("cancel afterEach", function() {
+            // unsubscribe to clean up after ourselves
+            if (testSubscription) {
+                testSubscription.dispose();
+            }
+        });
+
+        it("should subscribe and receive runCommonCommand results", function(done) {
+            var self = this,
+                uuid = helper.injector.get('uuid'),
+                testUuid = uuid.v4(),
+                testCommand = "soSomething",
+                testData = { abc: '123' };
+
+            self.task.subscribeRunCommonCommand(testUuid, testCommand, function(_data) {
+                try {
+                    expect(_data).to.deep.equal(testData);
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            }).then(function(subscription) {
+                expect(subscription).to.be.ok;
+
+                testSubscription = subscription;
+                return self.task.publishRunCommonCommand(testUuid, testCommand, testData);
+            }).catch(function(err) {
+                done(err);
+            });
+        });
+    });
+
+    describe("commonCommandResult", function() {
+
+        var testSubscription;
+        afterEach("cancel afterEach", function() {
+            // unsubscribe to clean up after ourselves
+            if (testSubscription) {
+                testSubscription.dispose();
+            }
+        });
+
+        it("should subscribe and receive common command results", function(done) {
+            var self = this,
+                uuid = helper.injector.get('uuid'),
+                testUuid = uuid.v4(),
+                testCommand = "soSomething",
+                testData = { abc: '123' };
+
+            self.task.subscribeCommonCommandResult(testUuid, testCommand, function(_data) {
+                try {
+                    expect(_data).to.deep.equal(testData);
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+
+            }).then(function(subscription) {
+                expect(subscription).to.be.ok;
+
+                testSubscription = subscription;
+                return self.task.publishCommonCommandResult(testUuid, testCommand, testData);
+            }).catch(function(err) {
+                done(err);
+            });
+        });
+    });
+
+
     describe("MetricResult", function() {
         var testSubscription;
         afterEach("cancel afterEach", function() {


### PR DESCRIPTION
1. add common network command publish/subscribe, used by tool like 'ping'
2. make amqp could publish string
3. support publish message to northbound LTAE, used for alert removing a node

Other related repo change links:
https://github.com/RackHD/on-tasks/pull/16
https://github.com/RackHD/on-taskgraph/pull/6
https://github.com/RackHD/on-http/pull/13
https://github.com/RackHD/onserve/pull/24

JIRA link:
https://hwjiraprd01.corp.emc.com/browse/ORFS-80
