### PR TITLE
Uses fixed version of node-crypt3

### DIFF
--- a/lib/common/encryption.js
+++ b/lib/common/encryption.js
@@ -85,4 +85,3 @@ function encryptionFactory(
 
     return Encryption;
 }
-

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "blocked": "^1.1.0",
     "bluebird": "^2.8.0",
     "colors": "^1.0.3",
+    "crypt3": "git+http://github.com/rolandpoulter/node-crypt3",
     "di": "git+https://5f5fdee3b5f3bc054cece98ad854c3090043f3c0:x-oauth-basic@github.com/RackHD/di.js.git",
     "ejs": "^2.0.8",
     "eventemitter2": "^0.4.14",
@@ -49,8 +50,7 @@
     "validate.js": "^0.3.2",
     "validator": "^3.27.0",
     "waterline": "^0.10.21",
-    "waterline-criteria": "^0.11.1",
-    "crypt3": "^0.1.8"
+    "waterline-criteria": "^0.11.1"
   },
   "devDependencies": {
     "chai": "^2.0.0",


### PR DESCRIPTION
I submitted a PR against node-crypt3, but it looks like the project is dead. I could push it to NPM under a different name?

Also the tests for this in `spec/lib/services/encryption-spec.js` do not pass on mac before or after this change.

https://hwjiraprd01.corp.emc.com/browse/MON-542

I setup travis-ci for node-crypt3 that builds it for node 0.10, 0.12, 4.0, 4.1 on linux and mac:
https://travis-ci.org/rolandpoulter/node-crypt3