### PR TITLE
Prevent AMQP subscription queues from being closed/deleted more than …

### DIFF
--- a/lib/common/subscription.js
+++ b/lib/common/subscription.js
@@ -7,10 +7,12 @@ module.exports = SubscriptionFactory;
 SubscriptionFactory.$provide = 'Subscription';
 SubscriptionFactory.$inject = [
     'Promise',
+    'Logger',
     'Assert'
 ];
 
-function SubscriptionFactory (Promise, assert) {
+function SubscriptionFactory (Promise, Logger, assert) {
+    var logger = Logger.initialize(SubscriptionFactory);
 
     /**
      * Creates a new subscription to a queue
@@ -21,8 +23,11 @@ function SubscriptionFactory (Promise, assert) {
         assert.object(queue, 'queue');
         assert.object(options, 'options');
 
+        this.MAX_DISPOSE_RETRIES = 3;
+        this.retryDelay = 1000;
         this.queue = queue;
         this.options = options;
+        this._disposed = false;
     }
 
     /**
@@ -30,8 +35,29 @@ function SubscriptionFactory (Promise, assert) {
      *
      * @returns {Promise}
      */
-    Subscription.prototype.dispose = function () {
+    Subscription.prototype.dispose = function (attempt, retry) {
         var self = this;
+        if (self._disposed && !retry) {
+            logger.warning('Subscription dispose was called more than once.', {
+                stack: new Error().stack,
+                consumerTag: self.options.consumerTag
+            });
+            return Promise.resolve(true);
+        } else {
+            self._disposed = true;
+        }
+
+        if (attempt === undefined) {
+            attempt = 0;
+        } else if (attempt >= self.MAX_DISPOSE_RETRIES) {
+            logger.error('Subscription failed to dispose with maximum retries.', {
+                consumerTag: self.options.consumerTag
+            });
+            return Promise.reject(new Error('Subscription ' + self.options.consumerTag +
+                        ' failed to dispose with maximum retries'));
+        }
+
+        attempt += 1;
 
         if (this.queue.state === 'open') {
             return Promise.resolve().then(function () {
@@ -42,11 +68,21 @@ function SubscriptionFactory (Promise, assert) {
                 return self.queue.close();
             }).then(function () {
                 return true;
+            }).catch(function(err) {
+                logger.error('Subscription failed to dispose, retrying attempt ' + attempt, {
+                    error: err
+                });
+                Promise.delay(self.retryDelay).then(function() {
+                    self.dispose(attempt, true);
+                });
+                throw err;
             });
         } else {
-            return Promise.reject(new Error('Subscription Already Disposed.'));
+            return Promise.reject(
+                    new Error('Attempted to dispose a subscription whose queue state is not open'));
         }
     };
 
     return Subscription;
 }
+


### PR DESCRIPTION
…once on dispose()

This was mistakenly only merged to master (see https://github.com/RackHD/on-core/pull/15 and https://github.com/RackHD/on-core/pull/16).
