### PR TITLE
Add task timeout error, de-serialize errors in task protocol cancel m…

### DIFF
--- a/lib/common/errors.js
+++ b/lib/common/errors.js
@@ -82,6 +82,12 @@ function ErrorFactory(util) {
     }
     util.inherits(TaskCancellationError, BaseError);
 
+    function TaskTimeoutError(message) {
+        BaseError.call(this, message);
+        Error.captureStackTrace(this, TaskTimeoutError);
+    }
+    util.inherits(TaskTimeoutError, BaseError);
+
     function TemplateRenderError(message) {
         BaseError.call(this, message);
         Error.captureStackTrace(this, TemplateRenderError);
@@ -118,6 +124,7 @@ function ErrorFactory(util) {
         LookupError: LookupError,
         SchemaError: SchemaError,
         TaskCancellationError: TaskCancellationError,
+        TaskTimeoutError: TaskTimeoutError,
         TemplateRenderError: TemplateRenderError,
         BreakPromiseChainError: BreakPromiseChainError,
         JobKilledError: JobKilledError,

--- a/lib/protocol/task.js
+++ b/lib/protocol/task.js
@@ -9,12 +9,13 @@ taskProtocolFactory.$inject = [
     'Promise',
     'Assert',
     'Constants',
+    'Errors',
     'Services.Messenger',
     '_',
     'Result'
 ];
 
-function taskProtocolFactory (Promise, assert, Constants, messenger, _, Result) {
+function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, Result) {
     function TaskProtocol() {
     }
 
@@ -41,13 +42,15 @@ function taskProtocolFactory (Promise, assert, Constants, messenger, _, Result) 
         );
     };
 
-    TaskProtocol.prototype.cancel = function (taskId, args) {
+    TaskProtocol.prototype.cancel = function (taskId, errName, errMessage) {
         assert.uuid(taskId);
+        assert.string(errName);
+        assert.string(errMessage);
 
         return messenger.publish(
             Constants.Protocol.Exchanges.Task.Name,
             'methods.cancel' + '.' + taskId,
-            new Result({ value: args })
+            { errName: errName, errMessage: errMessage }
         );
     };
 
@@ -59,7 +62,12 @@ function taskProtocolFactory (Promise, assert, Constants, messenger, _, Result) 
             Constants.Protocol.Exchanges.Task.Name,
             'methods.cancel' + '.' + taskId,
             function(data) {
-                callback(data.value);
+                // Re-create error sent over the wire
+                if (Errors[data.errName]) {
+                    callback(new Errors[data.errName](data.errMessage));
+                } else {
+                    callback(new Error(data.errMessage));
+                }
             }
         );
     };


### PR DESCRIPTION
…ethod

Task timeout errors have not been getting sent to running tasks, so on cancellation they end up getting marked as succeeded instead of timed out.

https://hwjiraprd01.corp.emc.com/browse/ODR-273
https://hwjiraprd01.corp.emc.com/browse/MON-633
