### PR TITLE
Remove sudo and package dependencies from travis file (so we can have…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-sudo: required
 language: node_js
-compiler: g++
 
 node_js:
   - "0.10"
@@ -9,12 +7,3 @@ node_js:
 services:
  - mongodb
  - rabbitmq
-
-before_install:
- - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
- - sudo apt-get update -qq
-
-install:
-- sudo apt-get install -qq g++-4.8
-- export CXX="g++-4.8"
-- npm install


### PR DESCRIPTION
… travis containers)

Our unit tests here shouldn't require sudo or apt updates, so remove them in order to support new travis containerized infrastructure.

Putting up a PR to test this, but I don't think it will work with on-core yet.