### PR TITLE
disabling node4 .travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,24 @@
 sudo: required
 language: node_js
-#compiler: g++
+compiler: g++
 
 node_js:
   - "0.10"
-#  - "4"
+  - "4"
+
+matrix:
+  allow_failures:
+   - node_js: "4"
 
 services:
  - mongodb
  - rabbitmq
 
-#before_install:
-# - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-# - sudo apt-get update -qq
-#
-#install:
-#- sudo apt-get install -qq g++-4.8
-#- export CXX="g++-4.8"
-#- npm install
+before_install:
+ - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+ - sudo apt-get update -qq
+
+install:
+- sudo apt-get install -qq g++-4.8
+- export CXX="g++-4.8"
+- npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 sudo: required
 language: node_js
-compiler: g++
+#compiler: g++
 
 node_js:
   - "0.10"
-  - "4"
+#  - "4"
 
 services:
  - mongodb
  - rabbitmq
 
-before_install:
- - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
- - sudo apt-get update -qq
-
-install:
-- sudo apt-get install -qq g++-4.8
-- export CXX="g++-4.8"
-- npm install
+#before_install:
+# - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+# - sudo apt-get update -qq
+#
+#install:
+#- sudo apt-get install -qq g++-4.8
+#- export CXX="g++-4.8"
+#- npm install


### PR DESCRIPTION
node4 builds have been providing to be unstable in timing or race conditions of some form in the extended unit test. Due to that instability, I'm proposing we disable the node4 builds for now (sorry @rolandpoulter) and work to resolving them in a branch before re-enabling node4 in travis.

Commenting out the detail in .travis.yml so we don't loose it and can re-enable in a branch to work it out.