### PR TITLE
removed globalstrict as it is deprecated

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -40,7 +40,6 @@
     "evil" : false,
     "expr" : true,     // true: Tolerate `ExpressionStatement` as Programs
     "funcscope" : false,
-    "globalstrict" : false,
     "iterator" : false,
     "lastsemic" : false,
     "laxbreak" : false,


### PR DESCRIPTION
When this is left in it causes jshint warnings when trying to override jshint for a certain file. 