### PR TITLE
Remove gs-stats to speed up npm install

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ module.exports = function (di, directory) {
                 helper.requireWrapper('pluralize', 'pluralize'),
                 helper.requireWrapper('blocked', 'blocked'),
                 helper.requireWrapper('always-tail', 'Tail'),
-                helper.requireWrapper('gc-stats', 'gc-stats'),
                 helper.requireWrapper('flat', 'flat'),
 
                 // Glob Requirables

--- a/lib/services/error-publisher.js
+++ b/lib/services/error-publisher.js
@@ -107,4 +107,3 @@ function ErrorPublisherFactory(
 
     return new ErrorPublisher();
 }
-

--- a/lib/services/statsd.js
+++ b/lib/services/statsd.js
@@ -12,7 +12,6 @@ statsdServiceFactory.$inject = [
     'node-statsd',
     'Assert',
     'Constants',
-    'gc-stats',
     'flat',
     '_'
 ];
@@ -24,18 +23,13 @@ function statsdServiceFactory(
     statsd,
     assert,
     Constants,
-    gcStats,
     flat,
     _
 ) {
     var uuidv4 = /\.[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
-        bsonid = /\.[0-9A-F]{24}$/i,
-        gcTypes = ['invalid', 'minor', 'major', 'both'];
+        bsonid = /\.[0-9A-F]{24}$/i;
 
-    function StatsDService () {
-        this.stats = gcStats();
-        this.stats.on('stats', this.publish.bind(this));
-    }
+    function StatsDService () {}
 
     util.inherits(StatsDService, statsd.StatsD);
 
@@ -64,17 +58,6 @@ function statsdServiceFactory(
         this.started = false;
 
         return Promise.resolve();
-    };
-
-    StatsDService.prototype.publish = function (data) {
-        if (this.started) {
-            var self = this,
-                stats = _.omit(flat(data), 'pause', 'pauseMS', 'gctype');
-
-            _.forIn(stats, function (value, key) {
-                self.gauge('process.gc.%s.%s'.format(key, gcTypes[data.gctype]), value);
-            });
-        }
     };
 
     StatsDService.prototype.sanitize = function (key) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "ejs": "^2.0.8",
     "eventemitter2": "^0.4.14",
     "flat": "^1.6.0",
-    "gc-stats": "1.0.0",
     "glob": "^4.3.2",
     "hogan.js": "^3.0.2",
     "jsonschema": "^1.0.0",


### PR DESCRIPTION
Installing `gc-stats` takes a long time because it has to do a lot of native compilation. In order to make npm install for `on-core` and its dependents I propose removing it.

~~I think `statsd` was only being used to broadcast info from `gc-stats` and AMQP request times. So I removed that as well. I can add `statsd` back if this is needed for something.~~

@benbp @DavidjohnBlodgett @VulpesArtificem