### PR TITLE
GRIP-17: Add scoping to templates

### DIFF
--- a/lib/common/template.js
+++ b/lib/common/template.js
@@ -57,9 +57,10 @@ function templateServiceFactory(FileLoader, Constants, Promise, _, waterline, Lo
         });
     };
 
-    TemplateService.prototype.put = function (file, contents) {
+    TemplateService.prototype.put = function (file, contents, scope) {
+        scope = scope || 'global';
         return Promise.resolve(
-            waterline.templates.findOne({ name: file })
+            waterline.templates.findOne({ name: file, scope: scope })
             .then(function(doc) {
                 if (!_.isEmpty(doc)) {
                     return waterline.templates.update(
@@ -70,7 +71,8 @@ function templateServiceFactory(FileLoader, Constants, Promise, _, waterline, Lo
                     return waterline.templates.create(
                         {
                             name: file,
-                            contents: contents
+                            contents: contents,
+                            scope: scope
                         }
                     );
                 }
@@ -78,16 +80,30 @@ function templateServiceFactory(FileLoader, Constants, Promise, _, waterline, Lo
         );
     };
 
-    TemplateService.prototype.get = function (name) {
-        return waterline.templates.findOne({ name: name });
+    TemplateService.prototype.get = function (name, scope) {
+        scope = scope || ['global'];
+
+        // The position of the tag defines the scope priority
+        var scopeWeight = {}, i = 1;
+        _.forEach(scope, function(item) {
+            scopeWeight[item] = i;
+            i += 1;
+        });
+
+        return waterline.templates.find({name: name, scope: scope}).then(function(templates) {
+            templates.sort(function(a,b) {
+                return scopeWeight[a.scope] - scopeWeight[b.scope];
+            });
+            return templates[0];
+        });
     };
 
     TemplateService.prototype.getAll = function () {
         return waterline.templates.find();
     };
 
-    TemplateService.prototype.render = function render (name, options) {
-        return this.get(name).then(function (template) {
+    TemplateService.prototype.render = function render (name, options, scope) {
+        return this.get(name, scope).then(function (template) {
             return ejs.render(template.contents, options);
         });
     };

--- a/lib/models/template.js
+++ b/lib/models/template.js
@@ -21,6 +21,10 @@ function TemplateModelFactory (Model) {
             contents: {
                 type: 'string',
                 required: true
+            },
+            scope: {
+                type: 'string',
+                defaultsTo: 'global'
             }
         }
     });


### PR DESCRIPTION
- Modify the model to add 'scope' and default it to 'global'
- Modify template retrieval to consider scope when returning documents
- Update/modify unittests
@RackHD/corecommitters 