### PR TITLE
Quieter normal eventloop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ node_modules
 # IDE
 .idea
 .tmp/
+.DS_Store

--- a/lib/services/error-publisher.js
+++ b/lib/services/error-publisher.js
@@ -27,8 +27,8 @@ function ErrorPublisherFactory(
     var logger = Logger.initialize(ErrorPublisherFactory);
 
     function severity(ms) {
-        if (ms < 100) {
-            return 'notice';
+        if (ms < 50) {
+            return 'debug';
         }
 
         if (ms < 500) {


### PR DESCRIPTION
Shifting logging level for event loop blocks under 50ms (from 100ms) from Notice to Debug level logging, to work with update to enable log filtering, and https://github.com/RackHD/RackHD/pull/30 to quiet down the demonstration log output