### PR TITLE
Adds node ID caching layer to lookup service.

### DIFF
--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -71,7 +71,7 @@ function lookupServiceFactory(
      * @constructor
      */
     function LookupService () {
-      this.resetNodeIdCache();
+        this.resetNodeIdCache();
     }
 
     /**
@@ -96,19 +96,19 @@ function lookupServiceFactory(
                               otherwise null.
      */
     LookupService.prototype.checkNodeIdCache = function (key) {
-      if (typeof this.nodeIdCache[key] === 'string') {
-          return Promise.resolve(this.nodeIdCache[key]);
-      }
+        if (typeof this.nodeIdCache[key] === 'string') {
+            return Promise.resolve(this.nodeIdCache[key]);
+        }
 
-      if (Array.isArray(this.nodeIdCache[key])) {
-          return new Promise(function (resolve) {
-              this.nodeIdCache[key].push(resolve);
-          }.bind(this));
-      }
+        if (Array.isArray(this.nodeIdCache[key])) {
+            return new Promise(function (resolve) {
+                this.nodeIdCache[key].push(resolve);
+            }.bind(this));
+        }
 
-      this.nodeIdCache[key] = [];
+        this.nodeIdCache[key] = [];
 
-      return null;
+        return null;
     };
 
     /**

--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -101,14 +101,15 @@ function lookupServiceFactory(
       }
 
       if (Array.isArray(this.nodeIdCache[key])) {
-          return new Promise(function (resolve, reject) {
+          return new Promise(function (resolve) {
               this.nodeIdCache[key].push(resolve);
           }.bind(this));
       }
 
       this.nodeIdCache[key] = [];
+
       return null;
-    }
+    };
 
     /**
      * Cache Node ID by either an IP or MAC address.
@@ -125,7 +126,9 @@ function lookupServiceFactory(
             });
         }
 
-        return this.nodeIdCache[key] = value;
+        this.nodeIdCache[key] = value;
+
+        return value;
     };
 
     /**

--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -71,7 +71,62 @@ function lookupServiceFactory(
      * @constructor
      */
     function LookupService () {
+      this.resetNodeIdCache();
     }
+
+    /**
+     * Reset all cached Node IDs.
+     */
+    LookupService.prototype.resetNodeIdCache = function () {
+        this.nodeIdCache = {};
+    };
+
+    /**
+     * Reset the cache for a specific IP or MAC address.
+     * @param  {String} cache key - IP or MAC address.
+     */
+    LookupService.prototype.clearNodeIdCache = function (key) {
+        this.nodeIdCache[key] = null;
+    };
+
+    /**
+     * Check the cache for a Node ID by IP or MAC addres.
+     * @param  {String} cache key - IP or MAC address.
+     * @return {Promise|null} Returns a promise if the Node ID is cached,
+                              otherwise null.
+     */
+    LookupService.prototype.checkNodeIdCache = function (key) {
+      if (typeof this.nodeIdCache[key] === 'string') {
+          return Promise.resolve(this.nodeIdCache[key]);
+      }
+
+      if (Array.isArray(this.nodeIdCache[key])) {
+          return new Promise(function (resolve, reject) {
+              this.nodeIdCache[key].push(resolve);
+          }.bind(this));
+      }
+
+      this.nodeIdCache[key] = [];
+      return null;
+    }
+
+    /**
+     * Cache Node ID by either an IP or MAC address.
+     * @param  {String} cache key - IP or MAC address.
+     * @param  {String} cache value - Node ID.
+     * @return {String} value converted to a string.
+     */
+    LookupService.prototype.assignNodeIdCache = function(key, value) {
+        value = value.toString();
+
+        if (Array.isArray(this.nodeIdCache[key])) {
+            this.nodeIdCache[key].forEach(function (resolve) {
+                resolve(value);
+            });
+        }
+
+        return this.nodeIdCache[key] = value;
+    };
 
     /**
      * Provides a middleware function suitable for
@@ -158,16 +213,26 @@ function lookupServiceFactory(
      * correlates to the provided MAC Address.
      */
     LookupService.prototype.macAddressToNodeId = function (macAddress) {
+        var cachePromise = this.checkNodeIdCache(macAddress);
+
+        if (cachePromise) {
+            return cachePromise;
+        }
+
         return waterline.lookups.findOneByTerm(macAddress).then(function (record) {
             if (record.node) {
-                return record.node;
-            } else {
+                return this.assignNodeIdCache(macAddress, record.node);
+            }
+
+            else {
+                this.clearNodeIdCache(macAddress);
+
                 throw new Errors.NotFoundError(
                     'Lookup Record Not Found (macAddressToNodeId)',
                     record
                 );
             }
-        });
+        }.bind(this));
     };
 
     /**
@@ -204,16 +269,26 @@ function lookupServiceFactory(
     LookupService.prototype.ipAddressToNodeId = function (ip) {
         assert.isIP(ip);
 
+        var cachePromise = this.checkNodeIdCache(ip);
+
+        if (cachePromise) {
+            return cachePromise;
+        }
+
         return waterline.lookups.findOneByTerm(ip).then(function (record) {
             if (record.node) {
-                return record.node;
-            } else {
+                return this.assignNodeIdCache(ip, record.node);
+            }
+
+            else {
+                this.clearNodeIdCache(ip);
+
                 throw new Errors.NotFoundError(
                     'Lookup Record Not Found (ipAddressToNodeId)',
                     record
                 );
             }
-        });
+        }.bind(this));
     };
 
     /**
@@ -250,4 +325,3 @@ function lookupServiceFactory(
 
     return new LookupService();
 }
-

--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -11,7 +11,8 @@ lookupServiceFactory.$inject = [
     'Services.Waterline',
     'Assert',
     'Errors',
-    '_'
+    '_',
+    'lru-cache'
 ];
 
 /**
@@ -33,7 +34,8 @@ function lookupServiceFactory(
     waterline,
     assert,
     Errors,
-    _
+    _,
+    LRU
 ) {
     // TODO: stolen from http-service could stand to be a re-usable helper.
     /**
@@ -78,7 +80,14 @@ function lookupServiceFactory(
      * Reset all cached Node IDs.
      */
     LookupService.prototype.resetNodeIdCache = function () {
-        this.nodeIdCache = {};
+        if (this.nodeIdCache) {
+            this.nodeIdCache.reset();
+            return;
+        }
+
+        this.nodeIdCache = LRU({
+            max: 500
+        });
     };
 
     /**
@@ -86,7 +95,7 @@ function lookupServiceFactory(
      * @param  {String} cache key - IP or MAC address.
      */
     LookupService.prototype.clearNodeIdCache = function (key) {
-        this.nodeIdCache[key] = null;
+        this.nodeIdCache.del(key);
     };
 
     /**
@@ -96,17 +105,19 @@ function lookupServiceFactory(
                               otherwise null.
      */
     LookupService.prototype.checkNodeIdCache = function (key) {
-        if (typeof this.nodeIdCache[key] === 'string') {
-            return Promise.resolve(this.nodeIdCache[key]);
+        var current = this.nodeIdCache.get(key);
+
+        if (typeof current === 'string') {
+            return Promise.resolve(current);
         }
 
-        if (Array.isArray(this.nodeIdCache[key])) {
+        if (Array.isArray(current)) {
             return new Promise(function (resolve) {
-                this.nodeIdCache[key].push(resolve);
+                current.push(resolve);
             }.bind(this));
         }
 
-        this.nodeIdCache[key] = [];
+        this.nodeIdCache.set(key, []);
 
         return null;
     };
@@ -120,13 +131,13 @@ function lookupServiceFactory(
     LookupService.prototype.assignNodeIdCache = function(key, value) {
         value = value.toString();
 
-        if (Array.isArray(this.nodeIdCache[key])) {
-            this.nodeIdCache[key].forEach(function (resolve) {
-                resolve(value);
-            });
-        }
+        var buffer = this.nodeIdCache.peek(key);
 
-        this.nodeIdCache[key] = value;
+        this.nodeIdCache.set(key, value);
+
+        if (Array.isArray(buffer)) {
+            buffer.forEach(function (resolve) { resolve(value); });
+        }
 
         return value;
     };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "hogan.js": "^3.0.2",
     "jsonschema": "^1.0.0",
     "lodash": "^2.4.1",
-    "lru-cache": "^2.5.0",
+    "lru-cache": "^3.2.0",
     "nconf": "^0.7.1",
     "node-statsd": "^0.1.1",
     "node-uuid": "^1.4.2",

--- a/spec/lib/serializables/ip-address-spec.js
+++ b/spec/lib/serializables/ip-address-spec.js
@@ -47,7 +47,7 @@ describe('IpAddress', function () {
                 return new IpAddress().validate().should.be.rejectedWith(Errors.SchemaError);
             });
 
-            it('should reject if value is not a mac address', function () {
+            it('should reject if value is not an ip address', function () {
                 return new IpAddress(
                     { value: 'invalid' }
                 ).validate().should.be.rejectedWith(Errors.SchemaError);

--- a/spec/lib/services/lookup-spec.js
+++ b/spec/lib/services/lookup-spec.js
@@ -39,41 +39,41 @@ describe('Lookup Service', function () {
             spy2 = sinon.spy();
 
         function assertEmptyNodeIdCacheObject() {
-          expect(lookupService.nodeIdCache).to.be.ok;
-          expect(Object.keys(lookupService.nodeIdCache).length).to.equal(0);
+            expect(lookupService.nodeIdCache).to.be.ok;
+            expect(lookupService.nodeIdCache.length).to.equal(0);
         }
 
         it('should start with an empty nodeCache', function () {
-          assertEmptyNodeIdCacheObject();
+            assertEmptyNodeIdCacheObject();
         });
 
         it('should allow multple simultaneous cache checks', function () {
-          expect(lookupService.checkNodeIdCache('testAddress')).to.be.null;
-          lookupService.checkNodeIdCache('testAddress').then(spy1, spy1);
-          lookupService.checkNodeIdCache('testAddress').then(spy2, spy2);
+            expect(lookupService.checkNodeIdCache('testAddress')).to.be.null;
+            lookupService.checkNodeIdCache('testAddress').then(spy1, spy1);
+            lookupService.checkNodeIdCache('testAddress').then(spy2, spy2);
         });
 
         it('should resolve pending cache checks once a value is assigned', function (done) {
-          lookupService.assignNodeIdCache('testAddress', 'nodeId');
-          setTimeout(function () {
-            expect(spy1.called).to.be.ok;
-            expect(spy2.called).to.be.ok;
-            done();
-          }, 0);
+            lookupService.assignNodeIdCache('testAddress', 'nodeId');
+            setTimeout(function () {
+                expect(spy1.called).to.be.ok;
+                expect(spy2.called).to.be.ok;
+                done();
+            }, 0);
         });
 
         it('should immediately resolve from cache', function (done) {
-          lookupService.checkNodeIdCache('testAddress').then(function (nodeId) {
-            expect(nodeId).to.equal('nodeId');
-            done();
-          });
+            lookupService.checkNodeIdCache('testAddress').then(function (nodeId) {
+                expect(nodeId).to.equal('nodeId');
+                done();
+            }, done);
         });
 
         it('should be able to be cleared and reset', function () {
-          lookupService.clearNodeIdCache('testAddress');
-          expect(lookupService.nodeIdCache.testAddress).to.equal(null);
-          lookupService.resetNodeIdCache();
-          assertEmptyNodeIdCacheObject();
+            lookupService.clearNodeIdCache('testAddress');
+            expect(lookupService.nodeIdCache.has('testAddress')).to.be.false;
+            lookupService.resetNodeIdCache();
+            assertEmptyNodeIdCacheObject();
         });
     });
 

--- a/spec/lib/services/lookup-spec.js
+++ b/spec/lib/services/lookup-spec.js
@@ -53,7 +53,7 @@ describe('Lookup Service', function () {
           lookupService.checkNodeIdCache('testAddress').then(spy2, spy2);
         });
 
-        it('should resolve pending cache checks once a value is assigned', function () {
+        it('should resolve pending cache checks once a value is assigned', function (done) {
           lookupService.assignNodeIdCache('testAddress', 'nodeId');
           setTimeout(function () {
             expect(spy1.called).to.be.ok;

--- a/spec/lib/services/lookup-spec.js
+++ b/spec/lib/services/lookup-spec.js
@@ -34,7 +34,54 @@ describe('Lookup Service', function () {
 
     helper.after();
 
+    describe('Node ID Cache', function () {
+        var spy1 = sinon.spy(),
+            spy2 = sinon.spy();
+
+        function assertEmptyNodeIdCacheObject() {
+          expect(lookupService.nodeIdCache).to.be.ok;
+          expect(Object.keys(lookupService.nodeIdCache).length).to.equal(0);
+        }
+
+        it('should start with an empty nodeCache', function () {
+          assertEmptyNodeIdCacheObject();
+        });
+
+        it('should allow multple simultaneous cache checks', function () {
+          expect(lookupService.checkNodeIdCache('testAddress')).to.be.null;
+          lookupService.checkNodeIdCache('testAddress').then(spy1, spy1);
+          lookupService.checkNodeIdCache('testAddress').then(spy2, spy2);
+        });
+
+        it('should resolve pending cache checks once a value is assigned', function () {
+          lookupService.assignNodeIdCache('testAddress', 'nodeId');
+          setTimeout(function () {
+            expect(spy1.called).to.be.ok;
+            expect(spy2.called).to.be.ok;
+            done();
+          }, 0);
+        });
+
+        it('should immediately resolve from cache', function (done) {
+          lookupService.checkNodeIdCache('testAddress').then(function (nodeId) {
+            expect(nodeId).to.equal('nodeId');
+            done();
+          });
+        });
+
+        it('should be able to be cleared and reset', function () {
+          lookupService.clearNodeIdCache('testAddress');
+          expect(lookupService.nodeIdCache.testAddress).to.equal(null);
+          lookupService.resetNodeIdCache();
+          assertEmptyNodeIdCacheObject();
+        });
+    });
+
     describe('macAddressToNodeId', function () {
+        beforeEach(function () {
+          lookupService.resetNodeIdCache();
+        });
+
         it('should call findByTerm with macAddress', function() {
             var findByTerm = this.sandbox.stub(waterline.lookups, 'findByTerm').resolves(lookup);
 
@@ -181,6 +228,10 @@ describe('Lookup Service', function () {
     });
 
     describe('ipAddressToNodeId', function () {
+        beforeEach(function () {
+          lookupService.resetNodeIdCache();
+        });
+
         it('should call findByTerm with ipAddress', function() {
             var findByTerm = this.sandbox.stub(waterline.lookups, 'findByTerm').resolves(lookup);
 
@@ -289,4 +340,3 @@ describe('Lookup Service', function () {
         });
     });
 });
-


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/rackhd/CiRQhVdkE38

Attempting to improve logging performance by introducing caching to lookup-service. First cache miss results in a DB query, subsequent cache lookups for the same IP or MAC address will wait for the first query to respond unless the there is already a valid entry in the cache.

This should greatly reduce number DB queries by the LookupService.