### PR TITLE
Issue#47: fix lookups doesn't return all records for empty query

### DIFF
--- a/lib/models/lookup.js
+++ b/lib/models/lookup.js
@@ -34,13 +34,17 @@ function LookupModelFactory (Model, assert, Errors, Promise, Constants) {
             }
         },
         findByTerm: function (term) {
-            return this.find({
-                or: [
-                    { node: term },
-                    { macAddress: term },
-                    { ipAddress: term }
-                ]
-            });
+            var query = {}; //empty query will find all entries
+            if (term) {
+                query = {
+                    or: [
+                        { node: term },
+                        { macAddress: term },
+                        { ipAddress: term }
+                    ]
+                };
+            }
+            return this.find(query);
         },
         findOneByTerm: function (term) {
             return this.findByTerm(term).then(function (records) {

--- a/spec/lib/models/lookup-spec.js
+++ b/spec/lib/models/lookup-spec.js
@@ -92,6 +92,24 @@ describe('Models.Lookup', function () {
                     });
                 });
             });
+
+            it('should call with empty criteria for empty term', function() {
+                var find = this.sandbox.stub(waterline.lookups, 'find').resolves([]);
+
+                return waterline.lookups.findByTerm('').then(function (records) {
+                    expect(records).to.deep.equal([]);
+                    expect(find).to.have.been.calledWith({});
+                });
+            });
+
+            it('should call with empty criteria if no term', function() {
+                var find = this.sandbox.stub(waterline.lookups, 'find').resolves([]);
+
+                return waterline.lookups.findByTerm().then(function (records) {
+                    expect(records).to.deep.equal([]);
+                    expect(find).to.have.been.calledWith({});
+                });
+            });
         });
 
         describe('findOneByTerm', function () {


### PR DESCRIPTION
Fix [Issue#47](https://github.com/RackHD/RackHD/issues/47).

Any detail, please go to that issue page.

@RackHD/corecommitters @iceiilin @WangWinson @cgx027 @pengz1 @sunnyqianzhang 