### PR TITLE
Waterline updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (di, directory) {
                 helper.requireWrapper('waterline', 'Waterline'),
                 helper.requireWrapper('waterline-criteria', 'WaterlineCriteria'),
                 helper.requireWrapper('sails-mongo', 'MongoAdapter'),
-                helper.requireWrapper('sails-disk', 'DiskAdapter'),
+                // helper.requireWrapper('sails-disk', 'DiskAdapter'),
                 helper.requireWrapper('amqp', 'amqp'),
                 helper.requireWrapper('domain', 'domain'),
                 helper.requireWrapper('node-uuid', 'uuid'),

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ module.exports = function (di, directory) {
                 helper.requireWrapper('waterline', 'Waterline'),
                 helper.requireWrapper('waterline-criteria', 'WaterlineCriteria'),
                 helper.requireWrapper('sails-mongo', 'MongoAdapter'),
-                // helper.requireWrapper('sails-disk', 'DiskAdapter'),
                 helper.requireWrapper('amqp', 'amqp'),
                 helper.requireWrapper('domain', 'domain'),
                 helper.requireWrapper('node-uuid', 'uuid'),

--- a/lib/services/waterline.js
+++ b/lib/services/waterline.js
@@ -11,7 +11,6 @@ WaterlineServiceFactory.$inject = [
     'Assert',
     'Waterline',
     'MongoAdapter',
-    // 'DiskAdapter',
     '_',
     '$injector'
 ];
@@ -22,7 +21,6 @@ function WaterlineServiceFactory(
     assert,
     Waterline,
     MongoAdapter,
-    // DiskAdapter,
     _,
     injector
 ) {
@@ -48,8 +46,6 @@ function WaterlineServiceFactory(
             self.config = {
                 adapters: {
                     mongo: MongoAdapter
-                    // ,
-                    // disk: DiskAdapter
                 },
                 connections: {
                     mongo: {

--- a/lib/services/waterline.js
+++ b/lib/services/waterline.js
@@ -7,7 +7,6 @@ module.exports = WaterlineServiceFactory;
 WaterlineServiceFactory.$provide = 'Services.Waterline';
 WaterlineServiceFactory.$inject = [
     'Promise',
-    'Rx',
     'Services.Configuration',
     'Assert',
     'Waterline',
@@ -19,7 +18,6 @@ WaterlineServiceFactory.$inject = [
 
 function WaterlineServiceFactory(
     Promise,
-    Rx,
     configuration,
     assert,
     Waterline,

--- a/lib/services/waterline.js
+++ b/lib/services/waterline.js
@@ -12,7 +12,7 @@ WaterlineServiceFactory.$inject = [
     'Assert',
     'Waterline',
     'MongoAdapter',
-    'DiskAdapter',
+    // 'DiskAdapter',
     '_',
     '$injector'
 ];
@@ -24,7 +24,7 @@ function WaterlineServiceFactory(
     assert,
     Waterline,
     MongoAdapter,
-    DiskAdapter,
+    // DiskAdapter,
     _,
     injector
 ) {
@@ -49,8 +49,9 @@ function WaterlineServiceFactory(
         return new Promise(function (resolve, reject) {
             self.config = {
                 adapters: {
-                    mongo: MongoAdapter,
-                    disk: DiskAdapter
+                    mongo: MongoAdapter
+                    // ,
+                    // disk: DiskAdapter
                 },
                 connections: {
                     mongo: {
@@ -113,4 +114,3 @@ function WaterlineServiceFactory(
 
     return new WaterlineService();
 }
-

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "prettyjson": "^1.0.0",
     "resolve": "^1.0.0",
     "rx": "^2.3.24",
-    "sails-disk": "0.10.7",
     "sails-mongo": "^0.10.5",
     "shortid": "^2.2.1",
     "stack-trace": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prettyjson": "^1.0.0",
     "resolve": "^1.0.0",
     "rx": "^2.3.24",
-    "sails-mongo": "^0.10.5",
+    "sails-mongo": "^0.11.5",
     "shortid": "^2.2.1",
     "stack-trace": "0.0.9",
     "validate.js": "^0.3.2",


### PR DESCRIPTION
While digging around looking at how we're reconnecting automatically on MongoDB, I saw we were downlevel and had some dead code enabled, so clipping things out and upgrading us to sails-mongo 11.5, which resolves https://github.com/RackHD/RackHD/issues/56.

Notes from @frey indicate that later versions of sails-mongo may not properly support the native drivers on unix, so taking a stab at this while I'm digging out the specifics of what is and isn't supported there.

According to https://docs.mongodb.org/ecosystem/drivers/node-js/, the underlying mongodb driver of 2.0.42 supports our versions of MongoDB and of Node.js:

- https://docs.mongodb.org/ecosystem/drivers/driver-compatibility-reference/#reference-compatibility-language-node
- https://docs.mongodb.org/ecosystem/drivers/driver-compatibility-reference/#reference-compatibility-mongodb-node

The only thing the docs assert it doesn't include is support for MongoDB 3.2
