### PR TITLE
add node relation mapping table

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -201,48 +201,56 @@ function constantsFactory (path) {
             ]
         },
         NodeRelations: {
+            /* There are two classes about the pair of relations:
+             * component: one node is a component of the other
+             *     e.g.  compute node vs. enclosure node
+             *     expect behavior:
+             *         the "By" in the relationType is used to tell component from its parent
+             *         delete a node as well as its components;
+             *         delete a component and update its parenet node
+             * link: two nodes is linked to each other
+             *     e.g.  compute node vs pdu node (TODO)
+             *     expect behavior:
+             *         delete one node and update the other
+            */
             encloses: {
                 mapping: 'enclosedBy',
-                // Delete all downstream node
-                delTargetNodeOption: 'all'
+                relationClass: 'component'
             },
             enclosedBy: {
                 mapping: 'encloses',
-                // Only delete downstream node when this relation in downstream are empty
-                delTargetNodeOption: 'whenEmpty'
+                relationClass: 'component'
             },
             /* Below are an example used to verify function
              * currently used in unit test
              compute node:
              "relations": [
                  {
-                     "relationType": "clusterBy",
+                     "relationType": "poweredBy",
                      "targets": [
                          "567b8f478b7444e407bb0729"
                      ]
                  }
              ],
-             cluster node:
+             pdu node:
              "relations": [
                  {
-                     "relationType": "cluster",
+                     "relationType": "powers",
                      "targets": [
                          "567b8f478b7444e407bb072a"
                          "567b8f478b7444e407bb072b"
                      ]
                  }
              ],
-             If all the compute nodes in cluster is removed, cluster node
-             will be removed as well. If cluster node is removed, compute
-             node still exist.
+             If either of them is removed, the other node will only be updated without deletion
             */
-            cluster: {
-                mapping: 'clusterBy',
-                delTargetNodeOption: null
+            powers: {
+                mapping: 'poweredBy',
+                relationClass: 'link'
             },
-            clusterBy: {
-                mapping: 'cluster',
-                delTargetNodeOption: 'whenEmpty'
+            poweredBy: {
+                mapping: 'powers',
+                relationClass: 'link'
             }
             /* end example */
         }

--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -199,6 +199,52 @@ function constantsFactory (path) {
                     type: 'compute'
                 }
             ]
+        },
+        NodeRelations: {
+            encloses: {
+                mapping: 'enclosedBy',
+                // Delete all downstream node
+                delDsNodeOption: 'all'
+            },
+            enclosedBy: {
+                mapping: 'encloses',
+                // Only delete downstream node when this relation in downstream are empty
+                delDsNodeOption: 'whenEmpty'
+            },
+            /* Below are an example used to verify function
+             * currently used in unit test
+             compute node:
+             "relations": [
+                 {
+                     "relationType": "clusterBy",
+                     "targets": [
+                         "567b8f478b7444e407bb0729"
+                     ]
+                 }
+             ],
+             cluster node:
+             "relations": [
+                 {
+                     "relationType": "cluster",
+                     "targets": [
+                         "567b8f478b7444e407bb072a"
+                         "567b8f478b7444e407bb072b"
+                     ]
+                 }
+             ],
+             If all the compute nodes in cluster is removed, cluster node
+             will be removed as well. If cluster node is removed, compute
+             node still exist.
+            */
+            cluster: {
+                mapping: 'clusterBy',
+                delDsNodeOption: null
+            },
+            clusterBy: {
+                mapping: 'cluster',
+                delDsNodeOption: 'whenEmpty'
+            }
+            /* end example */
         }
     });
 

--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -204,12 +204,12 @@ function constantsFactory (path) {
             encloses: {
                 mapping: 'enclosedBy',
                 // Delete all downstream node
-                delDsNodeOption: 'all'
+                delTargetNodeOption: 'all'
             },
             enclosedBy: {
                 mapping: 'encloses',
                 // Only delete downstream node when this relation in downstream are empty
-                delDsNodeOption: 'whenEmpty'
+                delTargetNodeOption: 'whenEmpty'
             },
             /* Below are an example used to verify function
              * currently used in unit test
@@ -238,11 +238,11 @@ function constantsFactory (path) {
             */
             cluster: {
                 mapping: 'clusterBy',
-                delDsNodeOption: null
+                delTargetNodeOption: null
             },
             clusterBy: {
                 mapping: 'cluster',
-                delDsNodeOption: 'whenEmpty'
+                delTargetNodeOption: 'whenEmpty'
             }
             /* end example */
         }


### PR DESCRIPTION
Add node relation mapping table.
I listed relation and its class ("link" and "component") here. It is used currently only for deleting node and updating its target nodes, but might extent to other actions (CRUD) in the future.

We can classify node relations into two classes: "component" and "link". If the relation is "component", its subordinate nodes will be deleted (like enclosure and compute); if the relation is "link", the target nodes will only be updated (like pdu and compute).

related PR:
https://github.com/RackHD/on-http/pull/80