### PR TITLE
Fix LookupService caching for failed promises.

### DIFF
--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -100,8 +100,9 @@ function lookupServiceFactory(
     };
 
     LookupService.prototype.clearNodeIdCacheAndThrow = function (key, error) {
-      this.clearNodeIdCache(key);
-      throw error;
+        this.clearNodeIdCache(key);
+
+        throw error;
     };
 
     /**
@@ -114,14 +115,25 @@ function lookupServiceFactory(
         var current = this.nodeIdCache.get(key);
 
         if (current === null || typeof current === 'string') {
-            return Promise.resolve(current);
+            return new Promise(function (resolve, reject) {
+                var responder = {resolve: resolve, reject: reject};
+
+                this.handleCachePromise(responder, current);
+            }.bind(this));
         }
 
         if (Array.isArray(current)) {
-            return new Promise(function (resolve) {
-                var buffer = this.nodeIdCache.get(key);
-                if (Array.isArray(buffer)) { buffer.push(resolve); }
-                else { resolve(buffer); }
+            return new Promise(function (resolve, reject) {
+                var buffer = this.nodeIdCache.get(key),
+                    responder = {resolve: resolve, reject: reject};
+
+                if (Array.isArray(buffer)) {
+                    buffer.push(responder);
+                }
+
+                else {
+                    this.handleCachePromise(responder);
+                }
             }.bind(this));
         }
 
@@ -137,17 +149,32 @@ function lookupServiceFactory(
      * @return {String} value converted to a string.
      */
     LookupService.prototype.assignNodeIdCache = function(key, value) {
-        value = value === null ? null : value.toString();
+        value = value && value.toString();
 
         var buffer = this.nodeIdCache.peek(key);
 
         this.nodeIdCache.set(key, value);
 
         if (Array.isArray(buffer)) {
-            buffer.forEach(function (resolve) { resolve(value); });
+            buffer.forEach(function (responder) {
+                this.handleCachePromise(responder, value);
+            }.bind(this));
         }
 
         return value;
+    };
+
+    LookupService.prototype.handleCachePromise = function (responder, value) {
+      if (!value) {
+          return responder.reject(
+              new Errors.NotFoundError(
+                  'Lookup Record Not Found (handleCachePromise)',
+                  null
+              )
+          );
+      }
+
+      responder.resolve(value);
     };
 
     /**

--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -86,7 +86,8 @@ function lookupServiceFactory(
         }
 
         this.nodeIdCache = LRU({
-            max: 500
+            max: 500,
+            maxAge: 30000
         });
     };
 
@@ -95,7 +96,12 @@ function lookupServiceFactory(
      * @param  {String} cache key - IP or MAC address.
      */
     LookupService.prototype.clearNodeIdCache = function (key) {
-        this.nodeIdCache.del(key);
+        this.assignNodeIdCache(key, null);
+    };
+
+    LookupService.prototype.clearNodeIdCacheAndThrow = function (key, error) {
+      this.clearNodeIdCache(key);
+      throw error;
     };
 
     /**
@@ -107,13 +113,15 @@ function lookupServiceFactory(
     LookupService.prototype.checkNodeIdCache = function (key) {
         var current = this.nodeIdCache.get(key);
 
-        if (typeof current === 'string') {
+        if (current === null || typeof current === 'string') {
             return Promise.resolve(current);
         }
 
         if (Array.isArray(current)) {
             return new Promise(function (resolve) {
-                current.push(resolve);
+                var buffer = this.nodeIdCache.get(key);
+                if (Array.isArray(buffer)) { buffer.push(resolve); }
+                else { resolve(buffer); }
             }.bind(this));
         }
 
@@ -129,7 +137,7 @@ function lookupServiceFactory(
      * @return {String} value converted to a string.
      */
     LookupService.prototype.assignNodeIdCache = function(key, value) {
-        value = value.toString();
+        value = value === null ? null : value.toString();
 
         var buffer = this.nodeIdCache.peek(key);
 
@@ -246,7 +254,7 @@ function lookupServiceFactory(
                     record
                 );
             }
-        }.bind(this));
+        }.bind(this)).catch(this.clearNodeIdCacheAndThrow.bind(this, macAddress));
     };
 
     /**
@@ -302,7 +310,7 @@ function lookupServiceFactory(
                     record
                 );
             }
-        }.bind(this));
+        }.bind(this)).catch(this.clearNodeIdCacheAndThrow.bind(this, ip));
     };
 
     /**

--- a/spec/lib/services/lookup-spec.js
+++ b/spec/lib/services/lookup-spec.js
@@ -71,7 +71,7 @@ describe('Lookup Service', function () {
 
         it('should be able to be cleared and reset', function () {
             lookupService.clearNodeIdCache('testAddress');
-            expect(lookupService.nodeIdCache.has('testAddress')).to.be.false;
+            expect(lookupService.nodeIdCache.peek('testAddress')).to.be.null;
             lookupService.resetNodeIdCache();
             assertEmptyNodeIdCacheObject();
         });


### PR DESCRIPTION
Main issue here was that I need to add `.catch` to calls to `waterline.lookups.findOneByTerm()` without it, it was not properly resolving cache promises. Which caused on-http to hang after the first cache lookup.

I also added better `null` caching and a `maxAge` of 30 seconds to the cache.

On my end there are still a few tests failing in on-http but I'm not sure if they are related or not, wanted to talk to Ben before I spent too much time debugging the remaining test failures.

This fixes a majority of the test failures currently in on-http.