### PR TITLE
Do not fail service startup if AMQP is not immediately available

### DIFF
--- a/lib/common/connection.js
+++ b/lib/common/connection.js
@@ -9,12 +9,11 @@ connectionFactory.$inject = [
     'Assert',
     'amqp',
     'Promise',
-    'EventEmitter',
     'Util',
     '_'
 ];
 
-function connectionFactory (assert, amqp, Promise, EventEmitter, util, _) {
+function connectionFactory (assert, amqp, Promise, util, _) {
     /**
      * Connection provides a wrapper around the AMQP connection logic
      * which presents a simplified interface for using multiple connections
@@ -22,11 +21,11 @@ function connectionFactory (assert, amqp, Promise, EventEmitter, util, _) {
      * @param {Object} options       node-amqp createConnection options.
      * @param {type} [clientOptions] node-amqp createConnection client options.
      */
-    function Connection (options, clientOptions) {
-        EventEmitter.call(this);
-
+    function Connection (options, clientOptions, label) {
         this.options = options;
         this.clientOptions = clientOptions;
+        this.label = label;
+        this.initialConnection = false;
 
         Object.defineProperty(this, 'exchanges', {
             get: function () {
@@ -42,8 +41,6 @@ function connectionFactory (assert, amqp, Promise, EventEmitter, util, _) {
             }
         });
     }
-
-    util.inherits(Connection, EventEmitter);
 
     /**
      * Starts the Connection
@@ -63,28 +60,22 @@ function connectionFactory (assert, amqp, Promise, EventEmitter, util, _) {
                 );
 
                 self.connection.on('ready', function () {
-                    self.emit('ready');
+                    resolve();
                 });
 
                 self.connection.on('error', function (error) {
                     // Suppress ECONNRESET which is very prevalent on Ubuntu
                     // when working with RabbitMQ.
-                    if (error.code !== 'ECONNRESET') {
-                        self.emit('error', error);
+                    if (error.code === 'ECONNRESET') {
+                        return;
                     }
-                });
-
-                self.connection.on('close', function () {
-                    self.emit('close');
-                });
-
-                // Setup emitters for Connection based on amqp.Connection.
-                self.once('ready', function () {
-                    resolve();
-                });
-
-                self.once('error', function (error) {
-                    reject(error);
+                    if (self.initialConnection) {
+                        console.log('AMQP %s Error (%s)'.format(self.label, self.options.url),
+                                    error.message);
+                    } else {
+                        console.log('Error creating initial AMQP %s connection (%s), retrying...'
+                                .format(self.label, self.options.url), error.message);
+                    }
                 });
             }
         });
@@ -99,7 +90,7 @@ function connectionFactory (assert, amqp, Promise, EventEmitter, util, _) {
 
         return new Promise(function (resolve, reject) {
             if (self.connection) {
-                self.once('close', function () {
+                self.connection.on('close', function () {
                     delete self.connection;
                     resolve();
                 });

--- a/lib/common/connection.js
+++ b/lib/common/connection.js
@@ -27,6 +27,7 @@ function connectionFactory (assert, amqp, Promise, util, _) {
         this.label = label;
         this.initialConnection = false;
         this.initialConnectionRetries = 0;
+        this.maxConnectionRetries = 60;
 
         Object.defineProperty(this, 'exchanges', {
             get: function () {
@@ -74,7 +75,7 @@ function connectionFactory (assert, amqp, Promise, util, _) {
                         console.log('AMQP %s Error (%s)'.format(self.label, self.options.url),
                                     error.message);
                     } else {
-                        if (self.initialConnectionRetries > 60) {
+                        if (self.initialConnectionRetries > self.maxConnectionRetries) {
                             reject(new Error(
                                     'Exceeded max retries attempting to start AMQP connection to ' +
                                     self.options.url));

--- a/lib/common/connection.js
+++ b/lib/common/connection.js
@@ -26,6 +26,7 @@ function connectionFactory (assert, amqp, Promise, util, _) {
         this.clientOptions = clientOptions;
         this.label = label;
         this.initialConnection = false;
+        this.initialConnectionRetries = 0;
 
         Object.defineProperty(this, 'exchanges', {
             get: function () {
@@ -73,6 +74,12 @@ function connectionFactory (assert, amqp, Promise, util, _) {
                         console.log('AMQP %s Error (%s)'.format(self.label, self.options.url),
                                     error.message);
                     } else {
+                        if (self.initialConnectionRetries > 60) {
+                            reject(new Error(
+                                    'Exceeded max retries attempting to start AMQP connection to ' +
+                                    self.options.url));
+                        }
+                        self.initialConnectionRetries += 1;
                         console.log('Error creating initial AMQP %s connection (%s), retrying...'
                                 .format(self.label, self.options.url), error.message);
                     }

--- a/lib/common/messenger.js
+++ b/lib/common/messenger.js
@@ -111,6 +111,13 @@ function messengerFactory(
         .then(function() {
             self.transmit.initialConnection = true;
             self.receive.initialConnection = true;
+        })
+        .catch(function(err) {
+            // Console log this since the logger may fail without the messenger,
+            // which itself is a seperate issue.
+            // TODO: remove console.log when the above ^^ comment is fixed.
+            console.log(err);
+            throw err;
         });
     };
 

--- a/lib/common/messenger.js
+++ b/lib/common/messenger.js
@@ -69,9 +69,8 @@ function messengerFactory(
 
     function Messenger () {
         this.startupPriority = 1;
-
+        this.initialConnection = false;
         this.subscriptions = {};
-
         this.timeout = 1000;
     }
 
@@ -88,37 +87,30 @@ function messengerFactory(
         assert.ok(uri, 'uri');
 
         var options = {
-                url: uri
-            },
-            clientOptions = {
-                reconnect: true,
-                reconnectBackoffStrategy: 'linear',
-                reconnectExponentialLimit: 120000,
-                reconnectBackoffTime: 1000
-            };
+            url: uri
+        };
+        var clientOptions = {
+            reconnect: true,
+            reconnectBackoffStrategy: 'linear',
+            reconnectExponentialLimit: 120000,
+            reconnectBackoffTime: 1000
+        };
 
-        // Setup Trasnsmit Connection.
-        this.transmit = new Connection (options, clientOptions);
-
-        this.transmit.on('error', function (error) {
-            console.log('AMQP Transmit Error (' + uri + ')', error.message);
-        });
-
-        // Setup Receive Connection
-        this.receive = new Connection(options, clientOptions);
-
-        this.receive.on('error', function (error) {
-            console.log('AMQP Receive Error (' + uri + ')', error.message);
-        });
+        this.transmit = new Connection (options, clientOptions, 'transmit');
+        this.receive = new Connection(options, clientOptions, 'receive');
 
         return Promise.all([
-            this.transmit.start(),
-            this.receive.start()
+            self.transmit.start(),
+            self.receive.start()
         ]).then(function () {
             _.mapValues(Constants.Protocol.Exchanges, function (exchange) {
                 self.receive.exchange(exchange.Name, exchange.Options);
                 self.transmit.exchange(exchange.Name, exchange.Options);
             });
+        })
+        .then(function() {
+            self.transmit.initialConnection = true;
+            self.receive.initialConnection = true;
         });
     };
 


### PR DESCRIPTION
Instead, try to reconnect a bunch of times, and only fail if we exceed the maximum attempts.

https://www.pivotaltracker.com/story/show/111023884

resolves https://github.com/RackHD/RackHD/issues/59