### PR TITLE
Upgrade lodash to version 3.10.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (di, directory) {
 
     return {
         helper: helper,
-        injectables: _.flatten(
+        injectables: _.flattenDeep(
             [
                 // NPM Packages
                 helper.simpleWrapper(_, '_'),

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -35,10 +35,9 @@ Object.defineProperty(Error.prototype, 'toJSON', {
 String.prototype.format = function () {
     return util.format.apply(
         null,
-        _.flatten([
+        _.flattenDeep([
             this,
             Array.prototype.slice.call(arguments)
         ])
     );
 };
-

--- a/lib/models/sku.js
+++ b/lib/models/sku.js
@@ -22,9 +22,9 @@ function SkuModelFactory (Model, _, assert, Validatable, Anchor) {
                 assert.arrayOfObject(rules, 'rules');
                 _.forEach(rules, function (rule) {
                     assert.string(rule.path, 'rule.path');
-                    _(_.omit(rule, 'path')).keys().forEach(function (key) {
+                    _(rule).omit('path').keys().forEach(function (key) {
                         assert.isIn(key, allRules, 'rule.' + key);
-                    });
+                    }).value();
                 });
                 return true;
             },
@@ -54,4 +54,3 @@ function SkuModelFactory (Model, _, assert, Validatable, Anchor) {
         }
     });
 }
-

--- a/lib/models/work-item.js
+++ b/lib/models/work-item.js
@@ -152,7 +152,7 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants) {
                     leaseExpires: null
                 });
             })).then(function (workItems) {
-                return _.flatten(workItems);
+                return _.flattenDeep(workItems);
             });
         },
 
@@ -174,7 +174,7 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants) {
                     leaseExpires: null
                 });
             })).then(function (workItems) {
-                return _.flatten(workItems);
+                return _.flattenDeep(workItems);
             });
         },
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "glob": "^4.3.2",
     "hogan.js": "^3.0.2",
     "jsonschema": "^1.0.0",
-    "lodash": "^2.4.1",
+    "lodash": "^3.10.1",
     "lru-cache": "^3.2.0",
     "nconf": "^0.7.1",
     "node-statsd": "^0.1.1",

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -128,7 +128,7 @@ global.helper = {
         if (overrides !== undefined) {
             // Overrids could be a single or an array so treat them
             // as equivalents by flattening.
-            _.flatten([overrides]).forEach(function (override) {
+            _.flattenDeep([overrides]).forEach(function (override) {
                 // Get the provider string for the current override.
                 var provides = provider(override);
 

--- a/spec/lib/models/sku-spec.js
+++ b/spec/lib/models/sku-spec.js
@@ -117,4 +117,3 @@ describe('Models.Sku', function () {
         });
     });
 });
-


### PR DESCRIPTION
This should be merged before the `on-http`, `on-syslog`, `on-tasks`, and `on-taskgraph` upgrades are merged. Those PRs will be opened shortly after this.

According to lodash changelog the `.flatten()` was changed to be shallow, so `.flattenDeep()` is now used instead to prevent breakage. Also when wrapping an object with lodash and then calling `.forEach()` will not iterate until `.value()` is called. It was changed to be lazily evaluated.
