### PR TITLE
add node relation mapping table

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -199,6 +199,60 @@ function constantsFactory (path) {
                     type: 'compute'
                 }
             ]
+        },
+        NodeRelations: {
+            /* There are two classes about the pair of relations:
+             * component: one node is a component of the other
+             *     e.g.  compute node vs. enclosure node
+             *     expect behavior:
+             *         the "By" in the relationType is used to tell component from its parent
+             *         delete a node as well as its components;
+             *         delete a component and update its parenet node
+             * link: two nodes are linked to each other
+             *     e.g.  compute node vs pdu node (TBD)
+             *     expect behavior:
+             *         delete one node and update the other
+            */
+            encloses: {
+                mapping: 'enclosedBy',
+                relationClass: 'component'
+            },
+            enclosedBy: {
+                mapping: 'encloses',
+                relationClass: 'component'
+            },
+            /* Below are an example used to verify function
+             * currently used in unit test
+             compute node:
+             "relations": [
+                 {
+                     "relationType": "poweredBy",
+                     "targets": [
+                         "567b8f478b7444e407bb0729"
+                     ]
+                 }
+             ],
+             pdu node:
+             "relations": [
+                 {
+                     "relationType": "powers",
+                     "targets": [
+                         "567b8f478b7444e407bb072a"
+                         "567b8f478b7444e407bb072b"
+                     ]
+                 }
+             ],
+             If either of them is removed, the other node will only be updated without deletion
+            */
+            powers: {
+                mapping: 'poweredBy',
+                relationClass: 'link'
+            },
+            poweredBy: {
+                mapping: 'powers',
+                relationClass: 'link'
+            }
+            /* end example */
         }
     });
 


### PR DESCRIPTION
PR to 1.1.0 branch, the same with https://github.com/RackHD/on-core/pull/55 that has been merged into master. 

It is a fix of ODR-314 required for 1.1.0. Implement full function about deleting nodes and update its related ones based on "relations" field in nodes/ document. This PR adds node relation mapping table.

related PR:
https://github.com/RackHD/on-http/pull/88