### PR TITLE
improve log output (color/level/caller)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,54 +9,62 @@ require('./lib/extensions');
 module.exports = function (di, directory) {
     var helper = require('./lib/di')(di, directory || __dirname);
 
+    var injectables = _.flattenDeep(
+        [
+            // NPM Packages
+            helper.simpleWrapper(_, '_'),
+            helper.requireWrapper('bluebird', 'Promise'),
+            helper.requireWrapper('rx', 'Rx'),
+            helper.requireWrapper('nconf'),
+            helper.requireWrapper('waterline', 'Waterline'),
+            helper.requireWrapper('waterline-criteria', 'WaterlineCriteria'),
+            helper.requireWrapper('sails-mongo', 'MongoAdapter'),
+            helper.requireWrapper('amqp', 'amqp'),
+            helper.requireWrapper('domain', 'domain'),
+            helper.requireWrapper('node-uuid', 'uuid'),
+            helper.requireWrapper('stack-trace', 'stack-trace'),
+            helper.requireWrapper('colors/safe', 'colors'),
+            helper.requireWrapper('prettyjson', 'prettyjson'),
+            helper.requireWrapper('lru-cache', 'lru-cache'),
+            helper.requireWrapper('node-statsd', 'node-statsd'),
+            helper.requireWrapper('validate.js', 'validate'),
+            helper.requireWrapper('validator', 'validator'),
+            helper.requireWrapper('assert-plus', 'assert-plus'),
+            helper.requireWrapper('ejs', 'ejs'),
+            helper.requireWrapper('hogan.js', 'Hogan'),
+            helper.requireWrapper('fs', 'fs'),
+            helper.requireWrapper('path', 'path'),
+            helper.requireWrapper('child_process', 'child_process'),
+            helper.requireWrapper('anchor', 'anchor'),
+            helper.requireWrapper('jsonschema', 'jsonschema'),
+            helper.simpleWrapper(console, 'console'),
+            helper.simpleWrapper(require('eventemitter2').EventEmitter2, 'EventEmitter'),
+            helper.requireWrapper('shortid', 'shortid'),
+            helper.requireWrapper('crypto', 'crypto'),
+            helper.requireWrapper('apache-crypt', 'apache-crypt'),
+            helper.requireWrapper('util', 'util'),
+            helper.requireWrapper('pluralize', 'pluralize'),
+            helper.requireWrapper('blocked', 'blocked'),
+            helper.requireWrapper('always-tail', 'Tail'),
+            helper.requireWrapper('flat', 'flat'),
+
+            // Glob Requirables
+            helper.requireGlob(__dirname + '/lib/common/*.js'),
+            helper.requireGlob(__dirname + '/lib/models/*.js'),
+            helper.requireGlob(__dirname + '/lib/protocol/*.js'),
+            helper.requireGlob(__dirname + '/lib/serializables/*.js'),
+            helper.requireGlob(__dirname + '/lib/services/*.js')
+        ]
+    );
+
+    var injector = new di.Injector(injectables);
+
+    // Run the common arguments handler
+    var argHandler = injector.get('Services.ArgumentHandler');
+    argHandler.start();
+
     return {
         helper: helper,
-        injectables: _.flattenDeep(
-            [
-                // NPM Packages
-                helper.simpleWrapper(_, '_'),
-                helper.requireWrapper('bluebird', 'Promise'),
-                helper.requireWrapper('rx', 'Rx'),
-                helper.requireWrapper('nconf'),
-                helper.requireWrapper('waterline', 'Waterline'),
-                helper.requireWrapper('waterline-criteria', 'WaterlineCriteria'),
-                helper.requireWrapper('sails-mongo', 'MongoAdapter'),
-                helper.requireWrapper('amqp', 'amqp'),
-                helper.requireWrapper('domain', 'domain'),
-                helper.requireWrapper('node-uuid', 'uuid'),
-                helper.requireWrapper('stack-trace', 'stack-trace'),
-                helper.requireWrapper('colors/safe', 'colors'),
-                helper.requireWrapper('prettyjson', 'prettyjson'),
-                helper.requireWrapper('lru-cache', 'lru-cache'),
-                helper.requireWrapper('node-statsd', 'node-statsd'),
-                helper.requireWrapper('validate.js', 'validate'),
-                helper.requireWrapper('validator', 'validator'),
-                helper.requireWrapper('assert-plus', 'assert-plus'),
-                helper.requireWrapper('ejs', 'ejs'),
-                helper.requireWrapper('hogan.js', 'Hogan'),
-                helper.requireWrapper('fs', 'fs'),
-                helper.requireWrapper('path', 'path'),
-                helper.requireWrapper('child_process', 'child_process'),
-                helper.requireWrapper('anchor', 'anchor'),
-                helper.requireWrapper('jsonschema', 'jsonschema'),
-                helper.simpleWrapper(console, 'console'),
-                helper.simpleWrapper(require('eventemitter2').EventEmitter2, 'EventEmitter'),
-                helper.requireWrapper('shortid', 'shortid'),
-                helper.requireWrapper('crypto', 'crypto'),
-                helper.requireWrapper('apache-crypt', 'apache-crypt'),
-                helper.requireWrapper('util', 'util'),
-                helper.requireWrapper('pluralize', 'pluralize'),
-                helper.requireWrapper('blocked', 'blocked'),
-                helper.requireWrapper('always-tail', 'Tail'),
-                helper.requireWrapper('flat', 'flat'),
-
-                // Glob Requirables
-                helper.requireGlob(__dirname + '/lib/common/*.js'),
-                helper.requireGlob(__dirname + '/lib/models/*.js'),
-                helper.requireGlob(__dirname + '/lib/protocol/*.js'),
-                helper.requireGlob(__dirname + '/lib/serializables/*.js'),
-                helper.requireGlob(__dirname + '/lib/services/*.js')
-            ]
-        )
+        injectables: injectables
     };
 };

--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -26,7 +26,7 @@ function constantsFactory (path) {
               error: 'red',
               warning: 'yellow',
               info: 'green',
-              debug: 'blue',
+              debug: 'cyan',
             },
             Levels: {
                 critical: 5,

--- a/lib/serializables/log-event.js
+++ b/lib/serializables/log-event.js
@@ -32,7 +32,10 @@ function LogEventFactory (
     pretty,
     console
 ) {
-    colors.setTheme(Constants.Logging.Colors);
+    //default turn off the colorful output to achieve tidy and clean log file.
+    LogEvent.colorEnable = false;
+
+    colors.setTheme(Constants.Logging.Colors); //setTheme will not impact color enable or not
 
     function LogEvent(defaults) {
         Serializable.call(this, LogEvent.schema, defaults);
@@ -80,9 +83,8 @@ function LogEventFactory (
         var statement = [];
 
         this.context = LogEvent.redact(this.context);
-
-        statement.push(this.level[0].toUpperCase());
-        statement.push(this.timestamp);
+        statement.push('[%s]'.format(this.level));
+        statement.push('[%s]'.format(this.timestamp));
         statement.push('[%s]'.format(this.name));
         statement.push('[%s]'.format(this.module));
         statement.push('[%s]'.format(
@@ -93,13 +95,16 @@ function LogEventFactory (
         var output = statement.join(' ');
 
         console.log(colors[this.level](output));
-        console.log(' -> ' + this.caller);
+        console.log(colors[this.level](' -> ' + this.caller));
 
         if (_.keys(this.context).length > 0) {
             console.log(
                 pretty.render(
                     this.context,
-                    { noColor: false }
+                    {
+                        noColor: !LogEvent.colorEnable,
+                        numberColor: 'cyan'
+                    }
                 )
             );
         }
@@ -117,6 +122,15 @@ function LogEventFactory (
             }).then(function (object) {
                 return object.validate();
             });
+    };
+
+    /**
+     * Set enabled or disabled for colorful log
+     * @param {boolean} enable - true to enable colorful log; false to disable
+     */
+    LogEvent.setColorEnable = function(enable) {
+        LogEvent.colorEnable = (enable ? true : false);
+        colors.enabled = LogEvent.colorEnable;
     };
 
     LogEvent.sanitize = function(context) {

--- a/lib/services/argument-handler.js
+++ b/lib/services/argument-handler.js
@@ -1,0 +1,60 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = argumentHandlerServiceFactory;
+
+argumentHandlerServiceFactory.$provide = 'Services.ArgumentHandler';
+argumentHandlerServiceFactory.$inject = [
+    '_',
+    'Services.Configuration',
+    'LogEvent'
+];
+
+function argumentHandlerServiceFactory(
+    _,
+    config,
+    LogEvent
+){
+    function ArgumentHandlerService() {}
+
+    /**
+     * Get the value from configuration by a collection of keys
+     *
+     * Sometimes we define different keys in configuration file and command line argument, because
+     * configuration file prefers the full key name, but command line prefers the short and mnemonic
+     * name. The argument handle can support the configuration from either file or command line, so
+     * this function is a helper to enumerate all keys, any key exists in configuration will return
+     * its value, if all keys don't exist, then return the default value.
+     * The earlier key in the input keys collection will take precedence over latter.
+     *
+     * @param {Collection} keys - the collection of keys
+     * @param {*} defaultValue - the default value that will be returned if all keys don't exist.
+     * @returns {*} the value of those keys, if all keys don't exist, will return the defaultValue.
+     */
+    ArgumentHandlerService.prototype._getValue = function(keys, defaultValue) {
+        var val;
+        _.forEach(keys, function(key) {
+            var v = config.get(key);
+            if (v !== undefined) {
+                val = v;
+                return false;
+            }
+        });
+        return (val === undefined ? defaultValue : val);
+    };
+
+    /**
+     * Start the argument handler service.
+     */
+    ArgumentHandlerService.prototype.start = function() {
+        //Configure the log colorful output
+        var colorEnable = this._getValue(['color', 'logColorEnable'], false);
+        LogEvent.setColorEnable(colorEnable);
+    };
+
+    ArgumentHandlerService.prototype.stop = function() {
+    };
+
+    return new ArgumentHandlerService();
+}

--- a/spec/lib/serializables/log-event-spec.js
+++ b/spec/lib/serializables/log-event-spec.js
@@ -5,11 +5,13 @@
 
 describe('LogEvent', function () {
     var LogEvent;
+    var lookupService;
 
     helper.before();
 
     before(function () {
         LogEvent = helper.injector.get('LogEvent');
+        lookupService = helper.injector.get('Services.Lookup');
     });
 
     helper.after();
@@ -67,6 +69,121 @@ describe('LogEvent', function () {
                 LogEvent.redact(target);
 
                 target.should.deep.equal({ password: 'bar' });
+            });
+        });
+
+        describe('getUniqueId', function() {
+            var sandbox;
+            before(function() {
+                sandbox = sinon.sandbox.create();
+            });
+
+            afterEach(function() {
+                sandbox.restore();
+            });
+
+            it('should return undefined for empty context', function() {
+                return LogEvent.getUniqueId().should.become(undefined);
+            });
+
+            it('should favor context.id', function() {
+                return LogEvent.getUniqueId({
+                    id: 'testid',
+                    macaddress: 'testmac',
+                    ip: 'testip'
+                }).should.become('testid');
+            });
+
+            it('should favor macaddress if id not exists', function() {
+                sandbox.stub(lookupService, 'macAddressToNodeId')
+                    .withArgs('testmac').resolves('aa:bb:cc:dd:ee:ff');
+                return LogEvent.getUniqueId({
+                    macaddress: 'testmac',
+                    ip: 'testip'
+                }).should.become('aa:bb:cc:dd:ee:ff');
+            });
+
+            it('should reject if lookup macaddress fails', function() {
+                sandbox.stub(lookupService, 'macAddressToNodeId')
+                    .withArgs('testmac').rejects();
+                return LogEvent.getUniqueId({
+                    macaddress: 'testmac',
+                    ip: 'testip'
+                }).should.be.rejected;
+            });
+
+            it('should favor ip if both id & macaddress not exists', function() {
+                sandbox.stub(lookupService, 'ipAddressToNodeId')
+                    .withArgs('testip').resolves('192.168.100.1');
+                return LogEvent.getUniqueId({
+                    ip: 'testip',
+                    other: 'testother'
+                }).should.become('192.168.100.1');
+            });
+
+            it('should reject if lookup ip fails', function() {
+                sandbox.stub(lookupService, 'ipAddressToNodeId')
+                    .withArgs('testip').rejects();
+                return LogEvent.getUniqueId({
+                    ip: 'testip',
+                    other: 'testother'
+                }).should.be.rejected;
+            });
+
+            it('should return undefined if id/macaddress/ip all not exist', function() {
+                return LogEvent.getUniqueId({
+                    'test': 'testmessage',
+                    'abc': 'testabc'
+                }).should.become(undefined);
+            });
+        });
+
+        describe('getSubject', function() {
+            var sandbox;
+            before(function() {
+                sandbox = sinon.sandbox.create();
+            });
+
+            afterEach(function() {
+                sandbox.restore();
+            });
+
+            it('should return subject', function() {
+                sandbox.stub(LogEvent, 'getUniqueId')
+                    .withArgs('testContext').resolves('testSubject');
+                return LogEvent.getSubject('testContext').should.become('testSubject');
+            });
+
+            it('should return default subject if getUniqueId returns empty', function() {
+                sandbox.stub(LogEvent, 'getUniqueId')
+                    .withArgs('testContext').resolves();
+                return LogEvent.getSubject('testContext').should.become('Server');
+            });
+
+            it('should return default subject if getUniqueId rejects', function() {
+                sandbox.stub(LogEvent, 'getUniqueId')
+                    .withArgs('testContext').rejects();
+                return LogEvent.getSubject('testContext').should.become('Server');
+            });
+        });
+
+        describe('setColorEnable', function() {
+            var colors;
+
+            before(function() {
+                colors = helper.injector.get('colors');
+            });
+
+            it('should enable colors', function() {
+                LogEvent.setColorEnable(true);
+                expect(colors.enabled).to.be.true;
+                expect(LogEvent.colorEnable).to.be.true;
+            });
+
+            it('should disable colors', function() {
+                LogEvent.setColorEnable(false);
+                expect(colors.enabled).to.be.false;
+                expect(LogEvent.colorEnable).to.be.false;
             });
         });
     });

--- a/spec/lib/services/argument-handler-spec.js
+++ b/spec/lib/services/argument-handler-spec.js
@@ -1,0 +1,95 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('Services.ArgumentHandler', function () {
+    var config, LogEvent;
+
+    helper.before();
+
+    before(function () {
+        config = helper.injector.get('Services.Configuration');
+        LogEvent = helper.injector.get('LogEvent');
+        this.subject = helper.injector.get('Services.ArgumentHandler');
+
+    });
+
+    helper.after();
+
+    describe('_getValue', function () {
+        var stubConfig;
+
+        before(function() {
+            stubConfig = sinon.stub(config, 'get', function(key, val) {
+                var obj = {
+                    a: 1,
+                    b: 'test',
+                    c: true
+                };
+                if (obj.hasOwnProperty(key)) {
+                    return obj[key];
+                } else {
+                    return val;
+                }
+            });
+        });
+
+        after(function() {
+            stubConfig.restore();
+        });
+
+        it('should return the correct lookup value', function() {
+            expect(this.subject._getValue(['a', 'b', 'c'], 'foo')).to.equal(1);
+            expect(this.subject._getValue(['x', 'b', 'c'], 'foo')).to.equal('test');
+            expect(this.subject._getValue(['x', 'y', 'c'], 'foo')).to.equal(true);
+        });
+
+        it('should return default value if all keys don\'t exist', function() {
+            expect(this.subject._getValue(['x', 'y', 'z'], 'foo')).to.equal('foo');
+        });
+
+        it('should return default value if keys are empty', function() {
+            expect(this.subject._getValue([], 'foo')).to.equal('foo');
+        });
+
+        it('should return undefined if no default value', function() {
+            expect(this.subject._getValue(['x', 'y', 'z'])).to.equal(undefined);
+        });
+
+        it('should return default value if keys are not collection', function() {
+            var self = this;
+            [null, 0, true, {}, undefined].forEach(function(key) {
+                expect(self.subject._getValue(key, 'foo')).to.equal('foo');
+            });
+        });
+    });
+
+    describe('start', function() {
+        var stubLogEvent;
+        var stubGetValue;
+
+        beforeEach(function() {
+            stubLogEvent = sinon.stub(LogEvent, 'setColorEnable');
+            stubGetValue = sinon.stub(this.subject, '_getValue');
+        });
+
+        afterEach(function() {
+            stubLogEvent.restore();
+            stubGetValue.restore();
+        });
+
+        it('should do enable color', function() {
+            stubGetValue.withArgs(['color', 'logColorEnable'], false).returns(true);
+            this.subject.start();
+            expect(stubLogEvent).to.have.callCount(1);
+            expect(stubLogEvent).to.have.been.calledWith(true);
+        });
+
+        it('should do disable color', function() {
+            stubGetValue.withArgs(['color', 'logColorEnable'], false).returns(false);
+            this.subject.start();
+            expect(stubLogEvent).to.have.callCount(1);
+            expect(stubLogEvent).to.have.been.calledWith(false);
+        });
+    });
+});


### PR DESCRIPTION
Change includes:

- default turn off colorful output, user can turn on the colorful output by configuration: --color or --logColorEnable
- create argument handler service as the common place for argument handling. 
- print full log level name
- print caller uses the same color of corresponding log level
- change the color for 'debug' level to cyan
- improve LogEvent unittest coverage

this change is from the google group discussion [Remove the color code from RackHD log file]( https://groups.google.com/forum/#!topic/rackhd/7xtNfbg9jzM)
The code follows the implementation of the "colors" module: https://github.com/Marak/colors.js/blob/master/lib%2Fsystem%2Fsupports-colors.js#L34-L38

@RackHD/corecommitters @iceiilin @WangWinson @cgx027 @pengz1 @sunnyqianzhang 