### PR TITLE
fix houndci false alarm about undefined variable

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -57,21 +57,18 @@
 
     // Environments
     "node": true,
+    "mocha": true,
 
     //Custom Globals
-    "globals" : {
-        "describe": false,
-        "it": false,
-        "before": false,
-        "beforeEach": false,
-        "after": false,
-        "afterEach": false,
-        "expect": false,
-        "should": false,
-        "request": false,
-        "helper": false,
-        "chai": false,
-        "sinon": false,
-        "Map": false
-    }
+    "predef" : [
+        "_",
+        "chai",
+        "expect",
+        "helper",
+        "Promise",
+        "request",
+        "should",
+        "sinon",
+        "sinonPromise"
+    ]
 }


### PR DESCRIPTION
Fix the annoying Hound CI false alarm for undefined variables by adding those variables into the jshint "predef" tables. (previous jshint "globals" options doesn't work well for houndci, but I tested "predef" works well, see my test PR: https://github.com/yyscamper/on-tasks/pull/10)

However, by introducing this change, there will be a new false alarm emerges:
```
Redefinition of '_'
```
This is caused by you use lodash not via injectable table but directly by require('lodash').
This false alarm usually only happens in "index.js", so it is rare to happen.

@RackHD/corecommitters @WangWinson @iceiilin 