### PR TITLE
Use array for exit code in child process

### DIFF
--- a/lib/common/child-process.js
+++ b/lib/common/child-process.js
@@ -49,12 +49,13 @@ function ChildProcessFactory (
         var self = this;
 
         assert.string(command);
+        assert.optionalArrayOfNumber(code);
 
         self.command = command;
         self.file = self._parseCommandPath(self.command);
         self.args = args;
         self.environment = env || {};
-        self.exitCode = code || 0;
+        self.exitCode = code || [0];
         self.maxBuffer = maxBuffer || Constants.ChildProcess.MaxBuffer;
 
         if (!self.file) {
@@ -136,7 +137,7 @@ function ChildProcessFactory (
         self.spawnInstance = nodeChildProcess.execFile(
                 self.file, self.args, options, function (error, stdout, stderr) {
 
-            if (error && error.code !== self.exitCode) {
+            if (error && self.exitCode.indexOf(error.code) === -1) {
                 self.hasBeenKilled = true;
                 logger.error('Error Running ChildProcess.', {
                     file: self.file,
@@ -145,7 +146,6 @@ function ChildProcessFactory (
                     stderr: stderr,
                     error: error
                 });
-
                 self.reject(error);
             } else {
                 self.hasBeenKilled = true;


### PR DESCRIPTION
Change accepted exit code in child process from a number to an array, which is align with bootstrap.js running in the node.