### PR TITLE
Force util.isError to return true for SchemaErrors

### DIFF
--- a/lib/common/validatable.js
+++ b/lib/common/validatable.js
@@ -43,7 +43,7 @@ function ValidatableFactory (Promise, _, jsonschema, Errors, assert) {
         if (_.isEmpty(outcome.errors)) {
             return Promise.resolve(target);
         } else {
-            return Promise.reject(new Errors.SchemaError(outcome));
+            return Promise.reject(new Error(new Errors.SchemaError(outcome)));
         }
     };
 

--- a/spec/lib/common/validatable-spec.js
+++ b/spec/lib/common/validatable-spec.js
@@ -47,7 +47,7 @@ describe('Validatable', function () {
             it('should reject on failure', function () {
                 return new Subject(
                     { name: 1337 }
-                ).validate().should.be.rejectedWith(Errors.SchemaError);
+                ).validate().should.be.rejectedWith(Error);
             });
         });
 
@@ -81,7 +81,7 @@ describe('Validatable', function () {
             it('should reject on failure', function () {
                 return new Subject(
                     { arbitrary: 1337 }
-                ).validate().should.be.rejectedWith(Errors.SchemaError);
+                ).validate().should.be.rejectedWith(Error);
             });
         });
 
@@ -115,7 +115,7 @@ describe('Validatable', function () {
             it('should reject non-ipv4', function () {
                 return new Subject(
                     { ip: 'garbage' }
-                ).validate().should.be.rejectedWith(Errors.SchemaError);
+                ).validate().should.be.rejectedWith(Error);
             });
         });
     });

--- a/spec/lib/serializables/ip-address-spec.js
+++ b/spec/lib/serializables/ip-address-spec.js
@@ -44,13 +44,13 @@ describe('IpAddress', function () {
 
         describe('rejected', function () {
             it('should reject if value is not present', function () {
-                return new IpAddress().validate().should.be.rejectedWith(Errors.SchemaError);
+                return new IpAddress().validate().should.be.rejectedWith(Error);
             });
 
             it('should reject if value is not a mac address', function () {
                 return new IpAddress(
                     { value: 'invalid' }
-                ).validate().should.be.rejectedWith(Errors.SchemaError);
+                ).validate().should.be.rejectedWith(Error);
             });
         });
     });

--- a/spec/lib/serializables/mac-address-spec.js
+++ b/spec/lib/serializables/mac-address-spec.js
@@ -44,13 +44,13 @@ describe('MacAddress', function () {
 
         describe('rejected', function () {
             it('should reject if value is not present', function () {
-                return new MacAddress().validate().should.be.rejectedWith(Errors.SchemaError);
+                return new MacAddress().validate().should.be.rejectedWith(Error);
             });
 
             it('should reject if value is not a mac address', function () {
                 return new MacAddress(
                     { value: 'invalid' }
-                ).validate().should.be.rejectedWith(Errors.SchemaError);
+                ).validate().should.be.rejectedWith(Error);
             });
         });
     });


### PR DESCRIPTION
This change is required to get the Swagger error handler to parse SchemaErrors properly (see https://github.com/RackHD/on-http/pull/119)

Swagger runs its error parser when next is called with a non-null error argument.  The error parser then uses util.isError to determine if the object is an Error.  Since util.isError only returns true if Object.prototype.toString.call(err) returns '[object Error]', util.isError returns false when it is passed an instance of jsonschema.SchemaError.  My solution is to wrap the SchemaError object in an Error object.

I'm not convinced this is the best way to solve this problem, so I'm open to suggestions.