### PR TITLE
Refactor on-core service unit-tests

### DIFF
--- a/spec/lib/services/encryption-spec.js
+++ b/spec/lib/services/encryption-spec.js
@@ -4,54 +4,72 @@
 'use strict';
 
 describe('Encryption Service', function () {
-    var Encryption;
+    var EncryptionService,
+        Encryption,
+        Configuration;
 
     helper.before();
 
     before(function () {
         Encryption = helper.injector.get('Encryption');
-        this.subject = helper.injector.get('Services.Encryption');
+        EncryptionService = helper.injector.get('Services.Encryption');
+        Configuration = helper.injector.get('Services.Configuration');
+        sinon.stub(Configuration);
     });
 
     helper.after();
+  
+    describe('start/stop', function () {
+        it('should call Encryption.prototype.start', function () {
+            Configuration.get.resolves('sharedKey');
+            return EncryptionService.start()
+            .then(function() {
+                expect(Promise.resolve()).to.be.ok;
+            });
+        });
+        
+        it('should call Encryption.prototype.stop', function () {
+            return EncryptionService.stop()
+            .then(function() {
+                expect(Promise.resolve()).to.be.ok;
+            });
+        });
+    });  
 
     describe('encrypt', function () {
         it('should call Encryption.prototype.encrypt', function () {
             var encrypt = this.sandbox.stub(Encryption.prototype, 'encrypt');
-
-            this.subject.encrypt('Hello World');
-
+            EncryptionService.encrypt('Hello World');
             encrypt.should.have.been.calledWith('Hello World');
         });
 
         it('should return the data if already encrypted', function() {
-            var target = this.subject.encrypt('NOOP');
-
-            this.subject.encrypt(target).should.equal(target);
+            var isEncrypted = this.sandbox.stub(Encryption.prototype, 'isEncrypted');
+            isEncrypted.resolves(true);
+            var target = EncryptionService.encrypt('NOOP');
+            EncryptionService.encrypt(target).should.equal(target);
         });
     });
 
     describe('decrypt', function () {
         it('should call Encryption.prototype.decrypt', function () {
-            var decrypt = this.sandbox.stub(Encryption.prototype, 'decrypt'),
-                target = this.subject.encrypt('Hello World');
-
-            this.subject.decrypt(target);
-
+            var isEncrypted = this.sandbox.stub(Encryption.prototype, 'isEncrypted'),
+                decrypt = this.sandbox.stub(Encryption.prototype, 'decrypt');
+            isEncrypted.resolves(false);
+            var target = EncryptionService.encrypt('Hello World');
+            EncryptionService.decrypt(target);
             decrypt.should.have.been.calledWith(target);
         });
 
         it('should return the data if already decrypted', function() {
-            this.subject.decrypt('NOOP').should.equal('NOOP');
+            EncryptionService.decrypt('NOOP').should.equal('NOOP');
         });
     });
 
     describe('createHash', function () {
         it('should call Encryption.prototype.createHash', function () {
             var hash = this.sandbox.stub(Encryption.prototype, 'createHash');
-
-            this.subject.createHash('Hello World');
-
+            EncryptionService.createHash('Hello World');
             hash.should.have.been.calledWith('Hello World');
         });
     });

--- a/spec/lib/services/waterline-spec.js
+++ b/spec/lib/services/waterline-spec.js
@@ -3,25 +3,63 @@
 'use strict';
 
 describe('Services.Waterline', function () {
-    var waterline;
+    var waterline,
+        sandbox = sinon.sandbox.create();
 
-    helper.before();
+    helper.before(function(context) {
+        context.Core = {
+            start: sandbox.stub().resolves(),
+            stop: sandbox.stub().resolves()
+        };
+        return helper.di.simpleWrapper(context.Core, 'Services.Core' );
+    });
 
     before(function() {
        waterline = helper.injector.get('Services.Waterline');
     });
 
     helper.after();
+    after(function() {
+        sandbox.restore();
+    });
 
     describe('start', function () {
+        it('should start service and resolve', function() {
+            waterline.service.initialize = this.sandbox.spy(function(cfg,callback) {
+                var ontology = {collections:{model:'model'}};
+                callback(undefined,ontology);
+            });
+            return waterline.start().should.be.resolved;
+        });
+        
         it('should resolve itself if already initialized', function() {
-            return waterline.start();
+            this.sandbox.stub(waterline, 'isInitialized').returns(true);
+            return waterline.start().should.be.resolved;
         });
 
         it('should reject if an error occurs when it is not initialized', function() {
             this.sandbox.stub(waterline, 'isInitialized').returns(false);
+            waterline.service.initialize = this.sandbox.spy(function(cfg,callback) {
+                callback(Error);
+            });
             return waterline.start().should.be.rejected;
         });
     });
+  
+    describe('stop', function () {
+        it('should teardown and resolve when initialized', function() {
+            waterline.service.teardown = this.sandbox.spy(function(callback) {
+                callback();
+            });
+            this.sandbox.stub(waterline, 'isInitialized').returns(true);
+            return waterline.stop();
+        });
+        
+        it('should resolve when not initialized', function() {
+            this.sandbox.stub(waterline, 'isInitialized').returns(false);
+            return waterline.stop();
+        });
+    });
+    
 });
 


### PR DESCRIPTION
- Remove core service dependencies (mongo,rabbitmq) from services tests. 

@RackHD/corecommitters @keedya @zyoung51 @uppalk1 @tannoa2 