### PR TITLE
Attempt fix for lookup record race condition

### DIFF
--- a/lib/models/lookup.js
+++ b/lib/models/lookup.js
@@ -92,7 +92,7 @@ function LookupModelFactory (Model, assert, Errors, Promise, Constants) {
                         self.destroy({ id: ipRecord.id })
                             .then(function() {
                                 delete ipRecord.ipAddress;
-                                self.create(ipRecord);
+                                return self.create(ipRecord);
                             })
                     ];
                 }


### PR DESCRIPTION
This handles a problem where we have a lookup record of mac->nodeId created by the linux cataloger job (analyzing `lshw` output), then later an ipAddress is associated with the record, and then later the DHCP lease expires and the IP is handed out elsewhere. The code in this case does not seem to succeed in re-creating the lookup document without the IP address, and it later gets created without any `node` attribute on reboot, thus causing lookup failures during OS installer workflows.

It seems that the waterline promise object probably doesn't execute the request until `.then()` is called, which is why adding a `return` statement makes this work, because before the `self.create` call was never executed.