### PR TITLE
Fetch all task definitions before doing cumulative updates to context…

### DIFF
--- a/lib/models/graph-object.js
+++ b/lib/models/graph-object.js
@@ -37,19 +37,6 @@ function GraphModelFactory (Model) {
             },
             node: {
                 model: 'nodes'
-            },
-            /*
-            runtime: {
-                collection: 'graphdependencies',
-                via: 'instanceId'
-            }
-            */
-            toJSON: function() {
-                var obj = this.toObject();
-                delete obj.createdAt;
-                delete obj.updatedAt;
-                delete obj.id;
-                return obj;
             }
         }
     });

--- a/lib/workflow/task-graph.js
+++ b/lib/workflow/task-graph.js
@@ -250,22 +250,32 @@ function taskGraphFactory(
             self._validateTaskLabels();
         })
         .then(function() {
+            assert.arrayOfObject(self.definition.tasks, 'Graph.tasks');
             return Promise.map(self.definition.tasks, function(taskData) {
-                if (_.has(taskData, 'taskDefinition')) {
+                if (!_.has(taskData, 'taskDefinition')) {
+                    return store.getTaskDefinition(taskData.taskName)
+                    .then(function(definition) {
+                        return {
+                            taskDefinition: definition,
+                            label: taskData.label
+                        };
+                    });
+                } else {
+                    return {
+                        taskDefinition: taskData.taskDefinition,
+                        label: taskData.label
+                    };
+                }
+            })
+            .then(function(tasks) {
+                _.forEach(tasks, function(taskData) {
                     self._validateTaskDefinition(taskData.taskDefinition);
                     self._validateProperties(taskData.taskDefinition, context);
                     self._validateOptions(taskData.taskDefinition, taskData.label);
-                } else {
-                    return store.getTaskDefinition(taskData.taskName)
-                    .then(function(taskDefinition) {
-                        self._validateTaskDefinition(taskDefinition);
-                        self._validateProperties(taskDefinition, context);
-                        self._validateOptions(taskDefinition, taskData.label);
-                    });
-                }
+                });
             });
         })
-        .spread(function() {
+        .then(function() {
             return self;
         });
     };


### PR DESCRIPTION
… object when validing properties

This fixes discovery on node v0.10. The context object is a shared object across multiple function calls when doing task graph property validation, but the ordering was dependent on the return order of a series of asynchronous calls, which was unreliable. This PR separates those two steps.

@RackHD/corecommitters @jlongever @johren @stuart-stanley @heckj @VulpesArtificem 