### PR TITLE
Persist task error messages

### DIFF
--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -105,7 +105,7 @@ function eventsProtocolFactory (Constants, messenger, assert) {
     };
 
     EventsProtocol.prototype.publishTaskFinished = function (
-            domain, taskId, graphId, state, context, terminalOnStates) {
+            domain, taskId, graphId, state, error, context, terminalOnStates) {
         assert.string(domain);
         assert.string(taskId);
         assert.uuid(graphId);
@@ -116,7 +116,7 @@ function eventsProtocolFactory (Constants, messenger, assert) {
         return messenger.publish(
             Constants.Protocol.Exchanges.Events.Name,
             domain + '.' + 'task.finished',
-            { taskId: taskId, graphId: graphId, state: state,
+            { taskId: taskId, graphId: graphId, state: state, error: error,
                 context: context, terminalOnStates: terminalOnStates }
         );
     };

--- a/lib/workflow/messengers/messenger-AMQP.js
+++ b/lib/workflow/messengers/messenger-AMQP.js
@@ -44,6 +44,7 @@ function amqpMessengerFactory(
         taskId,
         graphId,
         state,
+        error,
         context,
         terminalOnStates
     ) {
@@ -52,6 +53,7 @@ function amqpMessengerFactory(
                 taskId,
                 graphId,
                 state,
+                error,
                 context,
                 terminalOnStates
         );

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -136,8 +136,12 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
             $set: {}
         };
 
-        var _key = ['tasks', data.taskId, 'state'].join('.');
-        update.$set[_key] = data.state;
+        var stateKey = ['tasks', data.taskId, 'state'].join('.');
+        update.$set[stateKey] = data.state;
+        if (data.error) {
+            var errorKey = ['tasks', data.taskId, 'error'].join('.');
+            update.$set[errorKey] = data.error;
+        }
         _.forEach(data.context, function(val, key) {
             update.$set[['context', key].join('.')] = val;
         });

--- a/lib/workflow/task-graph.js
+++ b/lib/workflow/task-graph.js
@@ -489,10 +489,7 @@ function taskGraphFactory(
         var definition = data.definition;
         var options = data.options;
         var context = data.context;
-        // TODO: replace this with _.defaultsDeep when we upgrade to lodash 3 so
-        // that we don't have to call cloneDeep, and so that definition.options
-        // isn't a reference.
-        var _definition = _.defaultsDeep({}, definition);
+        var _definition = _.cloneDeep(definition);
         _definition.options = _.merge(definition.options || {}, options || {});
         return Promise.resolve()
         .then(function() {

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -117,6 +117,7 @@ describe("Event protocol subscribers", function () {
                     taskId: uuid.v4(),
                     graphId: uuid.v4(),
                     state: 'succeeded',
+                    error: null,
                     context: {},
                     terminalOnStates: ['failed', 'timeout']
                 };
@@ -135,6 +136,7 @@ describe("Event protocol subscribers", function () {
                     data.taskId,
                     data.graphId,
                     data.state,
+                    data.error,
                     data.context,
                     data.terminalOnStates
                 );

--- a/spec/lib/workflow/messengers/messenger-amqp-spec.js
+++ b/spec/lib/workflow/messengers/messenger-amqp-spec.js
@@ -103,11 +103,11 @@ describe('Task/TaskGraph AMQP messenger plugin', function () {
 
     it('should wrap the events protocol publishTaskFinished method', function() {
         return amqp.publishTaskFinished(
-            'default', 'testtaskid', 'testgraphid', 'succeeded', ['failed', 'timeout'])
+            'default', 'testtaskid', 'testgraphid', 'succeeded', null, ['failed', 'timeout'])
         .then(function() {
             expect(eventsProtocol.publishTaskFinished).to.have.been.calledOnce;
             expect(eventsProtocol.publishTaskFinished).to.have.been.calledWith(
-                'default', 'testtaskid', 'testgraphid', 'succeeded', ['failed', 'timeout']
+                'default', 'testtaskid', 'testgraphid', 'succeeded', null, ['failed', 'timeout']
             );
         });
     });

--- a/spec/lib/workflow/stores/mongo-spec.js
+++ b/spec/lib/workflow/stores/mongo-spec.js
@@ -93,26 +93,53 @@ describe('Task Graph mongo store interface', function () {
         });
     });
 
-    it('setTaskStateInGraph', function() {
-        var data = {
-            state: 'succeeded',
-            taskId: uuid.v4(),
-            graphId: uuid.v4()
-        };
+    describe('setTaskStateInGraph', function() {
+        it('should set a task state within a graph object', function() {
+            var data = {
+                state: 'succeeded',
+                taskId: uuid.v4(),
+                graphId: uuid.v4()
+            };
 
-        return mongo.setTaskStateInGraph(data)
-        .then(function() {
-            var modify = { $set: {} };
-            modify.$set['tasks.' + data.taskId + '.state'] = 'succeeded';
-            expect(waterline.graphobjects.findAndModifyMongo).to.have.been.calledOnce;
-            expect(waterline.graphobjects.findAndModifyMongo).to.have.been.calledWith(
-                {
-                    instanceId: data.graphId
-                },
-                {},
-                modify,
-                { new: true }
-            );
+            return mongo.setTaskStateInGraph(data)
+            .then(function() {
+                var modify = { $set: {} };
+                modify.$set['tasks.' + data.taskId + '.state'] = 'succeeded';
+                expect(waterline.graphobjects.findAndModifyMongo).to.have.been.calledOnce;
+                expect(waterline.graphobjects.findAndModifyMongo).to.have.been.calledWith(
+                    {
+                        instanceId: data.graphId
+                    },
+                    {},
+                    modify,
+                    { new: true }
+                );
+            });
+        });
+
+        it('should set a task state and error within a graph object', function() {
+            var data = {
+                state: 'succeeded',
+                error: new Error('test error message').toString(),
+                taskId: uuid.v4(),
+                graphId: uuid.v4()
+            };
+
+            return mongo.setTaskStateInGraph(data)
+            .then(function() {
+                var modify = { $set: {} };
+                modify.$set['tasks.' + data.taskId + '.state'] = 'succeeded';
+                modify.$set['tasks.' + data.taskId + '.error'] = 'Error: test error message';
+                expect(waterline.graphobjects.findAndModifyMongo).to.have.been.calledOnce;
+                expect(waterline.graphobjects.findAndModifyMongo).to.have.been.calledWith(
+                    {
+                        instanceId: data.graphId
+                    },
+                    {},
+                    modify,
+                    { new: true }
+                );
+            });
         });
     });
 

--- a/spec/lib/workflow/task-graph-spec.js
+++ b/spec/lib/workflow/task-graph-spec.js
@@ -50,6 +50,17 @@ describe('Task Graph', function () {
             store.getTaskDefinition.resolves(definitions.testTask);
         });
 
+        it('should not modify the definition by reference', function() {
+            // Ensure the waitOn properties of the definition object aren't changed, since
+            // TaskGraph should clone the object and change the waitOn properties to UUIDs
+            // on the clone.
+            expect(definitions.graphDefinition.tasks[1].waitOn).to.have.property('test-1');
+            return TaskGraph.create(undefined, { definition: definitions.graphDefinition })
+            .then(function() {
+                expect(definitions.graphDefinition.tasks[1].waitOn).to.have.property('test-1');
+            });
+        });
+
         it('should use the default domain', function() {
             return TaskGraph.create(undefined, { definition: definitions.graphDefinition })
             .then(function(graph) {


### PR DESCRIPTION
Persist task error messages in the graph document. This makes it easier to debug failed workflows. Minor feature regression.

@RackHD/corecommitters @VulpesArtificem 