### PR TITLE
add 'chai-string' to extend chai's string comparison assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "chai": "^2.0.0",
     "chai-as-promised": "^4.2.0",
+    "chai-string": "^1.2.0",
     "coveralls": "^2.11.4",
     "express": "^4.10.7",
     "grunt": "^0.4.5",

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -33,6 +33,7 @@ global.sinonPromise = require('sinon-as-promised')(bluebird);
 global.chai = require('chai');
 global.chai.use(require('chai-as-promised'));
 global.chai.use(require('sinon-chai'));
+global.chai.use(require('chai-string'));
 
 /**
  *  set up global expect for testing


### PR DESCRIPTION
I see @srinia6 extends the Chai with [chai-string](http://chaijs.com/plugins/chai-string/) to help some string comparison assertions (see this PR: https://github.com/RackHD/on-http/pull/137). I think this is a good extension and will probably be used by other repos, so its better to move it to on-core. Meanwhile, keep the Chai plugin installation in the same place (together with `Chai-as-promise` and `Chai-Sion`) will be better.
@RackHD/corecommitters @srinia6 @iceiilin @WangWinson @cgx027 @pengz1 @sunnyqianzhang 