### PR TITLE
remove configuration service deprecated warnning

### DIFF
--- a/lib/services/configuration.js
+++ b/lib/services/configuration.js
@@ -67,13 +67,6 @@ function configurationServiceFactory(
     ConfigurationService.prototype.get = function get(key, defaults) {
         assert.string(key, 'key');
 
-        if (!this.started) {
-            logger.deprecate(
-                'Attempting to access %s - prior to configuration service being started'.format(
-                    key), 3
-            );
-        }
-
         var value = nconf.get(key);
 
         if (value === undefined) {
@@ -89,13 +82,6 @@ function configurationServiceFactory(
     };
 
     ConfigurationService.prototype.getAll = function () {
-        if (!this.started) {
-            logger.deprecate(
-                'Attempting to access configuration values prior to ' +
-                'configuration service being started.', 3
-            );
-        }
-
         return nconf.get();
     };
 

--- a/spec/lib/common/logger-spec.js
+++ b/spec/lib/common/logger-spec.js
@@ -101,6 +101,7 @@ describe('Logger', function () {
                 });
 
                 it('should emit to the shared events object', function (done) {
+                    configuration.set('minLogLevel', 0); //set a min enough log level
                     this.subject[level]('message ' + level);
 
                     setImmediate(function () {


### PR DESCRIPTION
When running the unit-test in on-http, there will be plenty of Service.Configuration deprecated warning, it floods the console and hide those normal output. 

This warning is intended to ensure the `start` is called before query configuration, but the `start` does nothing right now. So it's safe to simply remove this warning.

Of course, there are alternative ways to achieve this:
(1) Make sure the cofiguration.start is called in any service, so I need to change every repo's index.js or add the configuration.start in on-core's index.js.
(2) Still enable this deprecated warning reporting, but constraint it is only report once for each service runtime.

My PR just choose the most simple fix, I have no preference on these 3 solutions and I'm happy to change it to another one if reviewer thinks another is better.

```
DEPRECATION: Services.Configuration - Attempting to access color - prior to configuration service being started /node_modules/on-core/lib/services/argument-handler.js:38
DEPRECATION: Services.Configuration - Attempting to access logColorEnable - prior to configuration service being started /node_modules/on-core/lib/services/argument-handler.js:38
DEPRECATION: Services.Configuration - Attempting to access color - prior to configuration service being started /node_modules/on-core/lib/services/argument-handler.js:38
DEPRECATION: Services.Configuration - Attempting to access logColorEnable - prior to configuration service being started /node_modules/on-core/lib/services/argument-handler.js:38
```

@RackHD/corecommitters @iceiilin @cgx027 @WangWinson @sunnyqianzhang @pengz1 