### PR TITLE
add workflowInjectables to unittest dependencies

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -121,7 +121,12 @@ global.helper = {
 
     setupInjector: function (overrides) {
         // Start with the core dependencies.
-        var dependencies = require('../index')(di, '..').injectables;
+        var core = require('../index')(di, '..');
+
+        var dependencies = _.flattenDeep([
+            core.injectables,
+            core.workflowInjectables
+        ]);
 
         // If overrides are provided then we'll process those before
         // creating the injector.


### PR DESCRIPTION
This is part of fix for https://github.com/RackHD/RackHD/issues/138

if the workflowInjetables are not added into the unit-test dependencies, then it bring much difficulty to every unit-test file if it depends on those modules that stored in workflowInjectables.

@RackHD/corecommitters @iceiilin @WangWinson @cgx027 @pengz1 @sunnyqianzhang 