### PR TITLE
change redaction to support regex and expand the redaction list

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -39,7 +39,7 @@ function constantsFactory (path) {
                 Length: 6
             },
             Sanitizations: ['id', 'mac', 'ip'],
-            Redactions: [ 'password' ]
+            Redactions: [ /password/i, /^community$/i ]
         },
         Configuration: {
             Files: {

--- a/lib/serializables/log-event.js
+++ b/lib/serializables/log-event.js
@@ -139,16 +139,19 @@ function LogEventFactory (
 
     /**
      * Initialize the redact regex
-     * By initializing all the redact regex in advance can speed up the subsequent testing
+     *
+     * By initializing all the redact 'RegExp' pattern in advance can speed up the subsequent
+     * testing; Keep the 'String` pattern of its original type can leverage the string comparasion
+     * which is faster than regex.
      *
      * @param {Array} redactions - The array of regex
      */
     LogEvent.initRedact = function(redactions) {
-        LogEvent._redactRegexes = _.reduce(redactions, function(result, value) {
-            if (_.isRegExp(value)) {
+        LogEvent._redactPatterns = _.reduce(redactions, function(result, value) {
+            if (_.isString(value)) {
+                result.push(value); //exactly full word match
+            } else if (_.isRegExp(value)) {
                 result.push(new RegExp(value));
-            } else if (_.isString(value)) {
-                result.push(new RegExp('^' + value + '$')); //exactly full word match
             } else {
                 console.log("warning: unsupported redaction type '" + typeof(value) + "', " +
                     "only 'RegExp' and 'String' is allowed.");
@@ -166,8 +169,17 @@ function LogEventFactory (
         if (!_.isString(value)) {
             return false;
         }
-        return _.some(LogEvent._redactRegexes, function(reg) {
-            return reg.test(value);
+
+        return _.some(LogEvent._redactPatterns, function(pattern) {
+            if (_.isString(pattern)) {
+                // The reason why use 'valueOf':
+                // new String('abc') is not strictly equal to new String('abc'),
+                // but new String('abc').valueOf() is strictly equal to new String('abc').valueOf()
+                return (pattern.valueOf() === value.valueOf());
+            }
+            else { //Regex
+                return pattern.test(value);
+            }
         });
     };
 

--- a/lib/serializables/log-event.js
+++ b/lib/serializables/log-event.js
@@ -137,13 +137,47 @@ function LogEventFactory (
         return _.omit(context, Constants.Logging.Sanitizations);
     };
 
+    /**
+     * Initialize the redact regex
+     * By initializing all the redact regex in advance can speed up the subsequent testing
+     *
+     * @param {Array} redactions - The array of regex
+     */
+    LogEvent.initRedact = function(redactions) {
+        LogEvent._redactRegexes = _.reduce(redactions, function(result, value) {
+            if (_.isRegExp(value)) {
+                result.push(new RegExp(value));
+            } else if (_.isString(value)) {
+                result.push(new RegExp('^' + value + '$')); //exactly full word match
+            } else {
+                console.log("warning: unsupported redaction type '" + typeof(value) + "', " +
+                    "only 'RegExp' and 'String' is allowed.");
+            }
+            return result;
+        }, []);
+    };
+
+    /**
+     * Test whether the value meet the redaction criteria
+     * @param {String} value - the target value to test
+     * @return {Boolean} true if it is need redaction, otherwise faluse
+     */
+    LogEvent.testRedact = function(value) {
+        if (!_.isString(value)) {
+            return false;
+        }
+        return _.some(LogEvent._redactRegexes, function(reg) {
+            return reg.test(value);
+        });
+    };
+
     LogEvent.redact = function (target) {
         return LogEvent._redact(_.cloneDeep(target));
     };
 
     LogEvent._redact = function (target) {
         return _.transform(target, function (accumulator, value, key) {
-            if (_.contains(key, Constants.Logging.Redactions)) {
+            if (LogEvent.testRedact(key)) {
                 accumulator[key] = '[REDACTED]';
             } else {
                 accumulator[key] = value;
@@ -199,5 +233,6 @@ function LogEventFactory (
             });
     };
 
+    LogEvent.initRedact(Constants.Logging.Redactions);
     return LogEvent;
 }

--- a/spec/lib/serializables/log-event-spec.js
+++ b/spec/lib/serializables/log-event-spec.js
@@ -47,14 +47,16 @@ describe('LogEvent', function () {
                 LogEvent.initRedact([/password/i, 'community', 123, ['a', 'b']]);
             });
 
-            it('should have initialized the redactions regex', function() {
-                LogEvent._redactRegexes.should.be.an.array;
-                LogEvent._redactRegexes.should.have.length(2);
-                _.forEach(LogEvent._redactRegexes, function(reg) {
-                    _.isRegExp(reg).should.be.true;
-                });
-                LogEvent._redactRegexes[0].toString().should.equal('/password/i');
-                LogEvent._redactRegexes[1].toString().should.equal('/^community$/');
+            it('should have initialized the RegExp redaction pattern in advance', function() {
+                LogEvent._redactPatterns.should.be.an.array;
+                LogEvent._redactPatterns.should.have.length(2);
+                _.isRegExp(LogEvent._redactPatterns[0]).should.be.true;
+                LogEvent._redactPatterns[0].toString().should.equal('/password/i');
+            });
+
+            it('should have kept the String redaction pattern of its original type', function() {
+                LogEvent._redactPatterns[1].should.be.a('string');
+                LogEvent._redactPatterns[1].toString().should.equal('community');
             });
 
             it('should not redact fields not marked for redaction', function() {

--- a/spec/lib/serializables/log-event-spec.js
+++ b/spec/lib/serializables/log-event-spec.js
@@ -21,8 +21,6 @@ describe('LogEvent', function () {
                 LogEvent.sanitize(
                     { foo: 'bar' }
                 ).should.deep.equal({ foo: 'bar' });
-
-
             });
 
             it('should remove fields marked for sanitization', function() {
@@ -39,36 +37,79 @@ describe('LogEvent', function () {
         });
 
         describe('redact', function() {
+            var testRedactKeys = ['password', 'PASSWORD', 'serverPassword', 'plainPassword',
+                'Password123', 'pppassword', 'encryptedPasswords', 'community'];
+            var testNotRedactKeys = ['pass_word', 'foobar', 'Community', 'community123',
+                'acommunity', 'p.assword'];
+
+            before('redact', function() {
+                //intentionally add some non-supported redactions to verify they are ignored
+                LogEvent.initRedact([/password/i, 'community', 123, ['a', 'b']]);
+            });
+
+            it('should have initialized the redactions regex', function() {
+                LogEvent._redactRegexes.should.be.an.array;
+                LogEvent._redactRegexes.should.have.length(2);
+                _.forEach(LogEvent._redactRegexes, function(reg) {
+                    _.isRegExp(reg).should.be.true;
+                });
+                LogEvent._redactRegexes[0].toString().should.equal('/password/i');
+                LogEvent._redactRegexes[1].toString().should.equal('/^community$/');
+            });
+
             it('should not redact fields not marked for redaction', function() {
-                LogEvent.redact(
-                    { foo: 'bar' }
-                ).should.deep.equal({ foo: 'bar' });
+                _.forEach(testNotRedactKeys, function(key) {
+                    var srcObj = {};
+                    srcObj[key] = 'bar';
+                    LogEvent.redact(srcObj).should.deep.equal(srcObj);
+                });
             });
 
             it('should redact fields which are marked for redaction', function() {
-                LogEvent.redact(
-                    { password: 'bar' }
-                ).should.deep.equal({ password: '[REDACTED]' });
+                _.forEach(testRedactKeys, function(key) {
+                    var srcObj = {}, dstObj = {};
+                    srcObj[key] = 'bar';
+                    dstObj[key] = '[REDACTED]';
+                    LogEvent.redact(srcObj).should.deep.equal(dstObj);
+                });
             });
 
             it('should redact fields in nested objects', function() {
-                LogEvent.redact(
-                    { nested: { password: 'bar' } }
-                ).should.deep.equal({ nested: { password: '[REDACTED]' } });
+                _.forEach(testRedactKeys, function(key) {
+                    var srcObj = { nested: {} };
+                    var dstObj = { nested: {} };
+                    srcObj.nested[key] = 'bar';
+                    dstObj.nested[key] = '[REDACTED]';
+                    LogEvent.redact(srcObj).should.deep.equal(dstObj);
+                });
             });
 
             it('should redact fields in nested arrays', function() {
-                LogEvent.redact(
-                    { array: [ { password: 'bar' } ] }
-                ).should.deep.equal({ array: [ { password: '[REDACTED]' } ] });
+                _.forEach(testRedactKeys, function(key) {
+                    var srcObj = { array: [ {} ] };
+                    var dstObj = { array: [ {} ] };
+                    srcObj.array[0][key] = 'bar';
+                    dstObj.array[0][key] = '[REDACTED]';
+                    LogEvent.redact(srcObj).should.deep.equal(dstObj);
+                });
             });
 
             it('should not modify the original object', function () {
-                var target = { password: 'bar' };
+                _.forEach(testRedactKeys, function(key) {
+                    var target = {};
+                    target[key] = 'bar';
+                    var cloneTarget = _.cloneDeep(target);
+                    LogEvent.redact(target);
+                    target.should.deep.equal(cloneTarget);
+                });
+            });
 
-                LogEvent.redact(target);
-
-                target.should.deep.equal({ password: 'bar' });
+            describe('LogEvent.testRedact', function() {
+                it('should return false if the tested value is not string', function() {
+                    _.forEach([1, {foo: 'bar'}, null, ['a', 'b'] ], function(val) {
+                        LogEvent.testRedact(val).should.be.false;
+                    });
+                });
             });
         });
 


### PR DESCRIPTION
I see we forgot to add some sensitive words into the redaction list, for example:
 - "plainPassword" & "encryptedPassword" & "rootPassword" & "rootEncryptedPassword" for OS bootstrap jobs.
 - "serverPassword" for all Dell RACDAM tasks.
- "community" for snmp.

This will cause to leak those sensitive information as they will be recorded in log files.
If adding these words one by one, the redaction list will become so big, so I changed the redaction to support the regex.

@RackHD/corecommitters @iceiilin @cgx027 @sunnyqianzhang @pengz1 

