### PR TITLE
Don't fail taskgraph option validation for falsey but valid option va…

### DIFF
--- a/lib/workflow/task-graph.js
+++ b/lib/workflow/task-graph.js
@@ -333,7 +333,7 @@ function taskGraphFactory(
             if (label && _.has(self.definition.options[label], k)) {
                 option = self.definition.options[label][k];
             }
-            assert.ok(option,
+            assert.ok((option != null), // jshint ignore:line
                 'required option ' + k + ' for task ' +
                 taskDefinition.injectableName + ' in graph ' + self.injectableName);
         });

--- a/spec/lib/workflow/task-graph-spec.js
+++ b/spec/lib/workflow/task-graph-spec.js
@@ -153,6 +153,40 @@ describe('Task Graph', function () {
             return Promise.all([p1, p2]);
         });
 
+        it('should not fail option validation on falsey option values', function() {
+            definitions.testTask.options.option1 = 0;
+            definitions.graphDefinitionInline.tasks[0].taskDefinition.options.option1 = 0;
+
+            return Promise.all([
+                expect(TaskGraph.create('domain',
+                        { definition: definitions.graphDefinition })).to.be.fulfilled,
+                expect(TaskGraph.create('domain',
+                    { definition: definitions.graphDefinitionInline })).to.be.fulfilled
+            ])
+            .then(function() {
+                definitions.testTask.options.option1 = false;
+                definitions.graphDefinitionInline.tasks[0].taskDefinition.options.option1 = false;
+
+                return Promise.all([
+                    expect(TaskGraph.create('domain',
+                            { definition: definitions.graphDefinition })).to.be.fulfilled,
+                    expect(TaskGraph.create('domain',
+                        { definition: definitions.graphDefinitionInline })).to.be.fulfilled
+                ]);
+            })
+            .then(function() {
+                definitions.testTask.options.option1 = '';
+                definitions.graphDefinitionInline.tasks[0].taskDefinition.options.option1 = '';
+
+                return Promise.all([
+                    expect(TaskGraph.create('domain',
+                            { definition: definitions.graphDefinition })).to.be.fulfilled,
+                    expect(TaskGraph.create('domain',
+                        { definition: definitions.graphDefinitionInline })).to.be.fulfilled
+                ]);
+            });
+        });
+
         it('should fail on task duplicate labels', function() {
             definitions.graphDefinition.tasks.push({
                 'label': 'test-duplicate'


### PR DESCRIPTION
…lues

This allows options that are included in `requiredOptions` to have falsey values.

@RackHD/corecommitters @VulpesArtificem @zyoung51 