### PR TITLE
Removes event loop blocked detection.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ module.exports = function (di, directory) {
             helper.requireWrapper('apache-crypt', 'apache-crypt'),
             helper.requireWrapper('util', 'util'),
             helper.requireWrapper('pluralize', 'pluralize'),
-            helper.requireWrapper('blocked', 'blocked'),
             helper.requireWrapper('always-tail', 'Tail'),
             helper.requireWrapper('flat', 'flat'),
 

--- a/lib/services/error-publisher.js
+++ b/lib/services/error-publisher.js
@@ -10,8 +10,7 @@ ErrorPublisherFactory.$inject = [
     'Promise',
     'Events',
     'Protocol.Events',
-    'Logger',
-    'blocked'
+    'Logger'
 ];
 
 function ErrorPublisherFactory(
@@ -19,31 +18,15 @@ function ErrorPublisherFactory(
     Promise,
     events,
     eventsProtocol,
-    Logger,
-    blocked
+    Logger
 ) {
     var logger = Logger.initialize(ErrorPublisherFactory);
-
-    function severity(ms) {
-        if (ms < 50) {
-            return 'debug';
-        }
-
-        if (ms < 500) {
-            return 'error';
-        }
-
-        return 'critical';
-    }
 
     function ErrorPublisher() {
         this.started = false;
 
         // These are emitted by the 'Events' EventEmitter.
         this.ignoredError = this.handleIgnoredError.bind(this);
-
-
-        blocked(this.handleBlockedEventLoop.bind(this));
     }
 
     ErrorPublisher.prototype.start = function() {
@@ -72,17 +55,6 @@ function ErrorPublisherFactory(
         }
 
         logger.debug('Ignored Error', { error: error });
-    };
-
-    ErrorPublisher.prototype.handleBlockedEventLoop = function (ms) {
-        var e = {
-            host: Constants.Host,
-            name: Constants.Name,
-            severity: severity(ms),
-            ms: ms
-        };
-
-        logger[e.severity]('Event Loop Blocked', e);
     };
 
     ErrorPublisher.prototype.stop = function() {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "anchor": "^0.10.2",
     "apache-crypt": "^1.0.9",
     "assert-plus": "^0.1.5",
-    "blocked": "^1.1.0",
     "bluebird": "^2.8.0",
     "colors": "^1.0.3",
     "di": "git+https://github.com/RackHD/di.js.git",


### PR DESCRIPTION
@RackHD/corecommitters

From a conversation with @benbp about changing the threshold for "Event Loop Blocked" appearing in the logs. Ultimately I thought we should remove this, because I believe it really does more harm than good. Mainly because `setInterval` is not very accurate, and even with an idle RackHD you'll still see "Event Loop Blocked" (50ms) debug logs.

I've seen people in RackHD ask about these logs, and that makes me feel they are somewhat confusing and noisy. Not really something that should be running in production.

We should use data from our automated tests to figure out where bottlenecks are and not rely on this kind of mechanism.