### PR TITLE
Bump node-assert-plus version to fix assert.optionalArrayOfNumber

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "amqp": "^0.2.3",
     "anchor": "^0.10.2",
     "apache-crypt": "^1.0.9",
-    "assert-plus": "^0.1.5",
+    "assert-plus": "^1.0.0",
     "bluebird": "^2.8.0",
     "colors": "^1.0.3",
     "di": "git+https://github.com/RackHD/di.js.git",

--- a/spec/lib/common/child-process-spec.js
+++ b/spec/lib/common/child-process-spec.js
@@ -123,7 +123,7 @@ describe("ChildProcess", function () {
         it("should reject if code are not an array of numbers", function () {
             expect(function() {
                 new ChildProcess("child-process-spec.js", null, null, 1);  // jshint ignore:line
-            }).to.throw('number ([number]) required');
+            }).to.throw(/.*\(\[number\]\) is required/);
         });
 
     });


### PR DESCRIPTION
@RackHD/corecommitters 

According the `assert-plus` the only breaking change from version 0.1.5 to 1.0.0 is that it will now accept Infinity as a Number.

I don't think RackHD will be affected by this breaking change. Updating the version fixes an issue where `assert.optionalArrayOfNumber` failed when given null. This was a bug in the older version of `assert-plus`

See https://github.com/RackHD/RackHD/issues/177