### PR TITLE
Set recursive to true when load templates

### DIFF
--- a/lib/common/db-renderable-content.js
+++ b/lib/common/db-renderable-content.js
@@ -50,7 +50,8 @@ function dbRenderableContentServiceFactory(
         var self = this;
 
         return this.loader.getAll(
-            self.directory
+            self.directory,
+            true
         ).then(function (templates) {
             var promises = _.map(templates, function (contents, name) {
                 return self.put(name, contents.toString());


### PR DESCRIPTION
The `FileLoader` [getAll] (https://github.com/RackHD/on-core/blob/master/lib/common/file-loader.js#L59) method has already support load file recursively in sub folder, set `recursive` true to enable add templates and profiles in sub folder.

@RackHD/corecommitters @sunnyqianzhang @iceiilin @cgx027 @pengz1 