### PR TITLE
Remove wrong parameters for taskprotocol's cancel

### DIFF
--- a/lib/protocol/task.js
+++ b/lib/protocol/task.js
@@ -40,13 +40,13 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         );
     };
 
-    TaskProtocol.prototype.cancel = function (taskId, errName, errMessage) {
+    TaskProtocol.prototype.cancel = function (taskId) {
         assert.uuid(taskId);
 
         return messenger.publish(
             Constants.Protocol.Exchanges.Task.Name,
             'methods.cancel',
-            { taskId: taskId, errName: errName, errMessage: errMessage }
+            { taskId: taskId }
         );
     };
 


### PR DESCRIPTION
resolve https://github.com/RackHD/RackHD/issues/191 .  from https://github.com/RackHD/on-taskgraph/blob/master/lib/task-scheduler.js#L382 . we can see that the default 2nd and 3rd parameters of cancel()  is index and length, not errName and errMessage, and if index and length are treated as errName and errMessage, it will lead to  https://github.com/RackHD/on-core/blob/master/lib/protocol/task.js#L53  functions' failure, and break https://github.com/RackHD/on-taskgraph/blob/master/lib/task-runner.js#L185 's cancelTask() execution, and lead to amqp's subscription not be cleaned up


