### PR TITLE
Changes to work-item model

### DIFF
--- a/lib/models/work-item.js
+++ b/lib/models/work-item.js
@@ -178,6 +178,14 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants) {
             });
         },
 
+        beforeValidate: function(obj, next) {
+            if (obj.type && _(Constants.WorkItems.Pollers).has(obj.type.toUpperCase())) {
+                obj.name = Constants.WorkItems.Pollers[obj.type.toUpperCase()];
+                delete obj.type;
+            }
+            next();
+        },
+
         beforeCreate: serialize,
 
         beforeUpdate: serialize,

--- a/lib/models/work-item.js
+++ b/lib/models/work-item.js
@@ -79,6 +79,13 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants) {
             paused:{
                 type: 'boolean',
                 defaultsTo: false
+            },
+            toJSON: function() {
+                var obj = this.toObject();
+                obj.config = _.omit(obj.config, function(value, key) {
+                    return String.prototype.match.apply(key, Constants.Logging.Redactions);
+                });
+                return obj;
             }
         },
 
@@ -207,7 +214,6 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants) {
                 return _.map(pollers, self.deserialize, self);
             });
         },
-
 
         deserialize: function(obj) {
             return sanitize(obj, /_/ig, '.');

--- a/spec/lib/models/work-item-spec.js
+++ b/spec/lib/models/work-item-spec.js
@@ -367,8 +367,38 @@ describe('Models.WorkItem', function () {
                  '_1_3_6_1_2_1_1_5'
             ]);
         });
+
+        it('should change poller.type to poller.name on create', function() {
+            var workItem = snmpPoller;
+
+            workItem.type = 'snmp';
+            delete workItem.name;
+
+            return workitems.create(workItem)
+            .then(function(createdItem) {
+                expect(createdItem.name).to.equal('Pollers.SNMP');
+                expect(createdItem).not.to.have.property('type');
+            });
+        });
+
+        it('should change poller.type to poller.name on update', function() {
+            var workItem = snmpPoller;
+
+            return workitems.create(workItem)
+            .then(function(createdItem) {
+                createdItem.type = 'ipmi';
+                delete createdItem.name;
+                return createdItem.save();
+            })
+            .then(function() {
+                return workitems.find({name: 'Pollers.IPMI'});
+            })
+            .then(function(items) {
+                expect(items.length).to.equal(1);
+                expect(items[0].name).to.equal('Pollers.IPMI');
+                expect(items[0]).not.to.have.property('type');
+            })
+        });
     });
-
-
 });
 


### PR DESCRIPTION
This patch includes changes to the work-item model that are needed to remove serializables from the 2.0 API pollers route.  Changes convert the pollers resource "type" property to "name" and redact passwords from poller config.