### PR TITLE
Bump mocha timeout to 10000 to mitigate potential jenkins issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "doc": "jsdoc lib -r -d docs",
-    "test": "./node_modules/.bin/mocha $(find spec -name '*-spec.js') -R spec --require spec/helper.js"
+    "test": "./node_modules/.bin/mocha --timeout 10000 $(find spec -name '*-spec.js') -R spec --require spec/helper.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Proposing a potential way to address what could be jenkins timeout issues when loading modules in mocha "before" blocks.

@RackHD/corecommitters @tldavies @davidzuhn 