### PR TITLE
Dockerfile refactor removes extra node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,6 @@ Dockerfile
 gruntfile.js
 HWIMO-*
 LICENSE
+node_modules/
 README.md
 spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,10 @@
 
 FROM mhart/alpine-node:4
 
-RUN apk add --update git
-
-RUN mkdir -p /RackHD/on-core
-
-COPY ./package.json /tmp/
-RUN cd /tmp && npm install --ignore-scripts --production
-
 COPY . /RackHD/on-core/
-RUN cp -a -f /tmp/node_modules /RackHD/on-core/
 
-ENV DEBIAN_FRONTEND noninteractive
+RUN apk add --update git \
+  && cd /RackHD/on-core \
+  && npm install --ignore-scripts --production
 
 VOLUME /opt/monorail


### PR DESCRIPTION
Removes extra copy of node_modules directory which reduces the size of the docker image.
