### PR TITLE
Add support for southbound API proxy server

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -307,6 +307,10 @@ function constantsFactory (path) {
                 ResourceRemoved: 'ResourceRemoved',
                 Alert: 'Alert'
             }
+        },
+        HttpHeaders: {
+            ApiProxyIp: 'X-RackHD-API-proxy-ip',
+            ApiProxyPort: 'X-RackHD-API-proxy-port'
         }
     });
 

--- a/lib/models/lookup.js
+++ b/lib/models/lookup.js
@@ -32,6 +32,9 @@ function LookupModelFactory (waterline, Model, assert, Errors, Promise, Constant
                 unique: true,
                 required: true,
                 regex: Constants.Regex.MacAddress
+            },
+            proxy: {
+                type: 'string'
             }
         },
         findByTerm: function (term) {
@@ -69,6 +72,27 @@ function LookupModelFactory (waterline, Model, assert, Errors, Promise, Constant
                     });
                 } else {
                     return self.create({ node: node, macAddress: macAddress });
+                }
+            });
+        },
+        upsertProxyToMacAddress: function (proxy, macAddress) {
+            assert.string(proxy, 'proxy');
+            assert.string(macAddress, 'macAddress');
+
+            var self = this;
+
+            return self.findOne({ macAddress: macAddress }).then(function (record) {
+                if (record) {
+                    return self.update(
+                        { id: record.id }, 
+                        { proxy: proxy }
+                    ).then(function (records) {
+                        return records[0];
+                    });
+                } else {
+                    throw new Errors.NotFoundError(
+                        'Lookup Record Not Found (upsertProxyToMacAddress)'
+                    );
                 }
             });
         },

--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -48,6 +48,10 @@ function lookupServiceFactory(
     function remoteAddress(req) {
         assert.ok(req, 'req');
 
+        if(req.get("X-Real-IP")) {
+            return req.get("X-Real-IP");
+        }
+        
         if (req.ip) {
             return req.ip;
         }
@@ -360,6 +364,23 @@ function lookupServiceFactory(
         });
     };
 
+    /**
+     * Returns the proxy server for the given Node ID.
+     * @param  {String} id Node ID
+     * @return {Promise.<String>} A promise fulfilled to the Proxy server URL
+     * that corresponds to this node
+     */
+    LookupService.prototype.nodeIdToProxy = function (id) {
+
+        return waterline.lookups.findOneByTerm(id).then(function (record) {
+            if (record && record.proxy) {
+                return record.proxy;
+            } else {
+                return undefined;
+            }
+        });
+    };
+    
     LookupService.prototype.setIpAddress = function (ip, mac) {
         return waterline.lookups.setIp(ip, mac);
     };

--- a/spec/lib/models/lookup-spec.js
+++ b/spec/lib/models/lookup-spec.js
@@ -210,6 +210,45 @@ describe('Models.Lookup', function () {
             });
         });
 
+        describe('upsertProxyToMacAddress', function () {
+            it('should update an existing record by mac adddress', function() {
+                var record = {
+                    id: 'id',
+                    macAddress: 'macAddress',
+                    ipAddress: 'ipAddress',
+                    node: 'node',
+                    proxy: 'proxy'
+                },
+                update = this.sandbox.stub(waterline.lookups, 'update').resolves([record]),
+                findOne = this.sandbox.stub(waterline.lookups, 'findOne').resolves(record);
+
+                return waterline.lookups.upsertProxyToMacAddress(
+                    'proxy',
+                    'macAddress'
+                ).then(function () {
+                    expect(findOne).to.have.been.calledWith({ macAddress: 'macAddress' });
+                    expect(update).to.have.been.calledWith({ id: 'id' }, { proxy: 'proxy' });
+                });
+            });
+
+            it('should be rejected with Errors.NotFoundError no record is returned by find', function() {
+                var record = {
+                    id: 'id',
+                    macAddress: 'macAddress',
+                    ipAddress: 'ipAddress',
+                    node: 'node'
+                },
+                findOne = this.sandbox.stub(waterline.lookups, 'findOne').resolves();
+
+                return expect(waterline.lookups.upsertProxyToMacAddress(
+                    'proxy',
+                    'macAddress'
+                )).to.be.rejectedWith(Errors.NotFoundError).then(function () {
+                    expect(findOne).to.have.been.calledWith({ macAddress: 'macAddress' });
+                });
+            });
+        });
+
         describe('setIp', function() {
             it('should set the mac with the ip', function() {
                 var record = {

--- a/spec/lib/models/lookup-spec.js
+++ b/spec/lib/models/lookup-spec.js
@@ -231,14 +231,8 @@ describe('Models.Lookup', function () {
                 });
             });
 
-            it('should be rejected with Errors.NotFoundError no record is returned by find', function() {
-                var record = {
-                    id: 'id',
-                    macAddress: 'macAddress',
-                    ipAddress: 'ipAddress',
-                    node: 'node'
-                },
-                findOne = this.sandbox.stub(waterline.lookups, 'findOne').resolves();
+            it('should reject with Errors.NotFoundError if no records are returned', function() {
+                var findOne = this.sandbox.stub(waterline.lookups, 'findOne').resolves();
 
                 return expect(waterline.lookups.upsertProxyToMacAddress(
                     'proxy',

--- a/spec/lib/services/lookup-spec.js
+++ b/spec/lib/services/lookup-spec.js
@@ -339,7 +339,12 @@ describe('Lookup Service', function () {
 
             this.sandbox.stub(lookupService, 'ipAddressToMacAddress').resolves('00:11:22:33:44:55');
 
-            var req = { ip: '10.1.1.1' },
+            var req = { 
+                    ip: '10.1.1.1',
+                    get: function() {
+                        return undefined;
+                    } 
+                },
                 next = function () {
                     expect(req.macaddress).to.equal('00:11:22:33:44:55');
                     expect(req.macAddress).to.equal('00:11:22:33:44:55');
@@ -354,7 +359,12 @@ describe('Lookup Service', function () {
 
             this.sandbox.stub(lookupService, 'ipAddressToMacAddress').resolves('00:11:22:33:44:55');
 
-            var req = { _remoteAddress: '10.1.1.1', },
+            var req = { 
+                    _remoteAddress: '10.1.1.1',
+                    get: function() {
+                        return undefined;
+                    }
+                }, 
                 next = function () {
                     expect(req.macaddress).to.equal('00:11:22:33:44:55');
                     expect(req.macAddress).to.equal('00:11:22:33:44:55');
@@ -369,11 +379,42 @@ describe('Lookup Service', function () {
 
             this.sandbox.stub(lookupService, 'ipAddressToMacAddress').resolves('00:11:22:33:44:55');
 
-            var req = { connection: { remoteAddress: '10.1.1.1' } },
+            var req = { 
+                    connection: { remoteAddress: '10.1.1.1' },
+                    get: function() {
+                        return undefined;
+                    }
+                },
                 next = function () {
                     expect(req.macaddress).to.equal('00:11:22:33:44:55');
                     expect(req.macAddress).to.equal('00:11:22:33:44:55');
                     done();
+                };
+
+            middleware(req, {}, next);
+        });
+
+        it('should assign macaddress to req with req.get(X-Real-IP)', function (done) {
+            var middleware = lookupService.ipAddressToMacAddressMiddleware();
+
+            this.sandbox.stub(lookupService, 'ipAddressToMacAddress').resolves('00:11:22:33:44:55');
+
+            var req = {
+                    get: function(header) {
+                        if(header === 'X-Real-IP') {
+                            return '10.1.1.1';
+                        }
+                        return undefined;
+                    }
+                },
+                next = function () {
+                    try {
+                        expect(req.macaddress).to.equal('00:11:22:33:44:55');
+                        expect(req.macAddress).to.equal('00:11:22:33:44:55');
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
                 };
 
             middleware(req, {}, next);
@@ -384,7 +425,11 @@ describe('Lookup Service', function () {
 
             this.sandbox.stub(lookupService, 'ipAddressToMacAddress').resolves(undefined);
 
-            var req = {},
+            var req = {
+                    get: function() {
+                        return undefined;
+                    }
+                },
                 next = function () {
                     expect(req.macaddress).to.equal(undefined);
                     done();

--- a/spec/lib/services/lookup-spec.js
+++ b/spec/lib/services/lookup-spec.js
@@ -23,6 +23,13 @@ describe('Lookup Service', function () {
         }
     ];
 
+    var withProxy = [{
+        ipAddress: '127.0.0.1',
+        macAddress: '00:11:22:33:44:55',
+        node: 'node',
+        proxy: '12.1.1.1'
+    }];
+
     var node = {
         id: 'node'
     };
@@ -329,6 +336,42 @@ describe('Lookup Service', function () {
                 lookupService.ipAddressToNodeId('127.0.0.1')
             ).to.be.rejectedWith(Errors.NotFoundError).then(function () {
                 expect(findByTerm).to.have.been.calledWith('127.0.0.1');
+            });
+        });
+    });
+
+   describe('nodeIdToProxy', function () {
+        beforeEach(function () {
+          lookupService.resetNodeIdCache();
+        });
+
+        it('should call findByTerm with nodeId', function() {
+            var findByTerm = this.sandbox.stub(
+                WaterlineService.lookups, 'findByTerm').resolves(withProxy);
+
+            return lookupService.nodeIdToProxy('node').then(function (result) {
+                expect(result).to.equal(withProxy[0].proxy);
+                expect(findByTerm).to.have.been.calledWith('node');
+            });
+        });
+
+        it('should reject with NotFoundError if no lookup record exists', function() {
+            var findByTerm = this.sandbox.stub(WaterlineService.lookups, 'findByTerm').resolves();
+
+            return expect(
+                lookupService.nodeIdToProxy('node')
+            ).to.be.rejectedWith(Errors.NotFoundError).then(function () {
+                expect(findByTerm).to.have.been.calledWith('node');
+            });
+        });
+
+        it('should return undefined if no proxy association exists', function() {
+            var findByTerm = this.sandbox.stub(
+                WaterlineService.lookups, 'findByTerm').resolves(lookup);
+
+            return lookupService.nodeIdToProxy('node').then(function (result) {
+                expect(result).to.equal(undefined);
+                expect(findByTerm).to.have.been.calledWith('node');
             });
         });
     });


### PR DESCRIPTION
In order to support running the RackHD on-taskgraph and on-http services on a host that does not have Layer-2 network access to the PXE network we need a host that does have access to the PXE network and can proxy requests to the southbound API endpoint over a management network.  

The proxy server, nginx in my POC, adds headers to the requests coming from the PXE client that contain headers that will be used during profile, template, and task rendering.

The headers are
X-Real-IP - the actual IP address of the PXE client
X-RackHD-api-proxy-ip - The IP address of the API proxy server
X-RackHD-api-proxy-port - The port of the API proxy server

The proxy server URL is added to the lookup record for the PXE client so that it can be used during task rendering since the original HTTP request is not available at that time.

on-http PR: https://github.com/RackHD/on-http/pull/274
on-tasks PR: https://github.com/RackHD/on-tasks/pull/185

This is one of three pull requests.  There will also be subsequent changes to on-http and on-tasks to support this.
[test-coverage.tar.gz](https://github.com/RackHD/on-core/files/255346/test-coverage.tar.gz)


