### PR TITLE
added unique flag for indexes

### DIFF
--- a/lib/models/task-dependency.js
+++ b/lib/models/task-dependency.js
@@ -19,8 +19,15 @@ function TaskDependencyFactory (Model, Constants) {
                 type: 'string',
                 defaultsTo: Constants.Task.DefaultDomain
             },
+            taskId: {
+                type: 'string',
+                required: true,
+                unique: true,
+                uuidv4: true
+            },
             graphId: {
                 type: 'string',
+                unique: true,
                 required: true
             },
             state: {

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -51,27 +51,13 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
     /**
      * @param {Object} indexObject an object with keys that correspond to the mogo
      * collections on which to place indexes and values that are arrays of indexes
-     * @example {
-     *       taskdependencies: [
-     *           {index: {taskId: 1}, unique: true},
-     *           {index: {graphId: 1}},
-     *           {index: {taskId: 1, graphId: 1}}
-     *       ],
-     *       graphobjects: [
-     *           {index: {instanceId: 1}, unique: true}
-     *       ]
-     *  }
      * @memberOf store
      * @returns {Promise}
      */
     exports.setIndexes = function(indexObject) {
-        return Promise.all(_.flatten(_.map(indexObject, function(indexArray, key) {
-                return _.map(indexArray, function(indexObj) {
-                    if(indexObj.unique) {
-                        return waterline[key].createUniqueMongoIndexes([indexObj.index]);
-                    } else {
-                        return waterline[key].createMongoIndexes(indexObj.index);
-                    }
+        return Promise.all(_.flatten(_.map(indexObject, function(indexObj, key) {
+                return _.map(indexObj, function(index) {
+                    return waterline[key].createMongoIndexes(index);
                 });
             }))
         );

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -52,22 +52,26 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
      * @param {Object} indexObject an object with keys that correspond to the mogo
      * collections on which to place indexes and values that are arrays of indexes
      * @example {
-     *          taskdependencies: [
-     *              {taskId: 1},
-     *              {graphId: 1},
-     *              {taskId: 1, graphId: 1}
-     *          ],
-     *          graphobjects: [
-     *              {instanceId: 1}
-     *          ]
+     *       taskdependencies: [
+     *           {index: {taskId: 1}, unique: true},
+     *           {index: {graphId: 1}},
+     *           {index: {taskId: 1, graphId: 1}}
+     *       ],
+     *       graphobjects: [
+     *           {index: {instanceId: 1}, unique: true}
+     *       ]
      *  }
      * @memberOf store
      * @returns {Promise}
      */
     exports.setIndexes = function(indexObject) {
-        return Promise.all(_.flatten(_.map(indexObject, function(indexObj, key) {
-                return _.map(indexObj, function(index) {
-                    return waterline[key].createMongoIndexes(index);
+        return Promise.all(_.flatten(_.map(indexObject, function(indexArray, key) {
+                return _.map(indexArray, function(indexObj) {
+                    if(indexObj.unique) {
+                        return waterline[key].createUniqueMongoIndexes([indexObj.index]);
+                    } else {
+                        return waterline[key].createMongoIndexes(indexObj.index);
+                    }
                 });
             }))
         );
@@ -196,7 +200,7 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
     /**
     * Deletes a graph definition of the graphdefinitions collection
     * @param {String} injectableName - name of Graph to delete
-    * @returns {Promise} a promise 
+    * @returns {Promise} a promise
     * @memberOf store
     */
     exports.destroyGraphDefinition = function(injectableName) {
@@ -302,8 +306,8 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
      * @param {Object} taskDependencyItem - the task object
      * @param {String} taskDependencyItem.taskId - the unique ID for the task
      * @param {Object} taskDependencyItem.dependencies - the list of dependencies for the task
-     * @param {String[]} taskDependencyItem.terminalOnStates - the list of states for which this task
-     * can be the last task in its graph
+     * @param {String[]} taskDependencyItem.terminalOnStates - the list of states for
+     * which this task can be the last task in its graph
      * @param {String} graphId - the unique ID of the graph to which the task belongs
      * @returns {Promise} a promise for the created taskdependency object
      * @memberOf store

--- a/spec/lib/workflow/stores/mongo-spec.js
+++ b/spec/lib/workflow/stores/mongo-spec.js
@@ -19,7 +19,6 @@ describe('Task Graph mongo store interface', function () {
             find: sinon.stub().resolves(),
             create: sinon.stub().resolves(),
             createMongoIndexes: sinon.stub().resolves(),
-            createUniqueMongoIndexes: sinon.stub().resolves(),
             destroy: sinon.stub().resolves(),
             mongo: { objectId: sinon.stub() }
         };
@@ -675,24 +674,14 @@ describe('Task Graph mongo store interface', function () {
     it('setIndexes', function() {
         var indexObject = {
             taskdependencies: [
-                {index: {taskId: 1}, unique: true},
-                {index: {graphId: 1}},
-                {index: {taskId: 1, graphId: 1}}
-            ],
-            graphobjects: [
-                {index: {instanceId: 1}, unique: true}
+                {taskId: 1, graphId: 1}
             ]
         };
 
         return mongo.setIndexes(indexObject)
         .then(function() {
-            expect(waterline.graphobjects.createUniqueMongoIndexes).to.be
-                .calledWithExactly([indexObject.graphobjects[0].index]);
-            expect(waterline.taskdependencies.createUniqueMongoIndexes).to.be
-                .calledWithExactly([indexObject.taskdependencies[0].index]);
             expect(waterline.taskdependencies.createMongoIndexes).to.be
-                .calledWithExactly(indexObject.taskdependencies[1].index).and
-                .calledWithExactly(indexObject.taskdependencies[2].index);
+                .calledWithExactly({taskId: 1, graphId: 1});
         });
     });
 });

--- a/spec/lib/workflow/stores/mongo-spec.js
+++ b/spec/lib/workflow/stores/mongo-spec.js
@@ -18,6 +18,8 @@ describe('Task Graph mongo store interface', function () {
             findOne: sinon.stub().resolves(),
             find: sinon.stub().resolves(),
             create: sinon.stub().resolves(),
+            createMongoIndexes: sinon.stub().resolves(),
+            createUniqueMongoIndexes: sinon.stub().resolves(),
             destroy: sinon.stub().resolves(),
             mongo: { objectId: sinon.stub() }
         };
@@ -667,6 +669,30 @@ describe('Task Graph mongo store interface', function () {
             expect(waterline.graphdefinitions.destroy).to.have.been.calledWith(
                 {injectableName: 'testname'}
             );
+        });
+    });
+
+    it('setIndexes', function() {
+        var indexObject = {
+            taskdependencies: [
+                {index: {taskId: 1}, unique: true},
+                {index: {graphId: 1}},
+                {index: {taskId: 1, graphId: 1}}
+            ],
+            graphobjects: [
+                {index: {instanceId: 1}, unique: true}
+            ]
+        };
+
+        return mongo.setIndexes(indexObject)
+        .then(function() {
+            expect(waterline.graphobjects.createUniqueMongoIndexes).to.be
+                .calledWithExactly([indexObject.graphobjects[0].index]);
+            expect(waterline.taskdependencies.createUniqueMongoIndexes).to.be
+                .calledWithExactly([indexObject.taskdependencies[0].index]);
+            expect(waterline.taskdependencies.createMongoIndexes).to.be
+                .calledWithExactly(indexObject.taskdependencies[1].index).and
+                .calledWithExactly(indexObject.taskdependencies[2].index);
         });
     });
 });


### PR DESCRIPTION
changed the mongo store setIndexes function to read a 'unique: true' flag and call the underlying method for  creating unique indexes in order to restore uniqueness constraints lost in the Big Taskgraph Refactor.
supports https://github.com/RackHD/on-taskgraph/pull/96
@RackHD/corecommitters @rolandpoulter  

