### PR TITLE
this updates always-tail to the newest version 0.2.0. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/RackHD/on-core",
   "dependencies": {
-    "always-tail": "^0.1.1",
+    "always-tail": "^0.2.0",
     "amqp": "0.2.3",
     "anchor": "^0.10.2",
     "apache-crypt": "1.0.9",


### PR DESCRIPTION
The new version does not throw a String when it cant find the file to tail. 