### PR TITLE
Move ARP poller job as on-core service

### DIFF
--- a/lib/services/arp-poller.js
+++ b/lib/services/arp-poller.js
@@ -1,0 +1,146 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = arpPollerFactory;
+di.annotate(arpPollerFactory, new di.Provide('Services.ArpPoller'));
+di.annotate(arpPollerFactory, new di.Inject(
+    'Services.Lookup',
+    'Services.Waterline',
+    'Logger',
+    'Promise',
+    'Rx',
+    'Assert',
+    'Util',
+    '_',
+    'fs',
+    'Services.Configuration'
+));
+
+function arpPollerFactory(
+    lookupService,
+    waterline,
+    Logger,
+    Promise,
+    Rx,
+    assert,
+    util,
+    _,
+    nodeFs,
+    configuration
+) {
+    var logger = Logger.initialize(arpPollerFactory);
+    var fs = Promise.promisifyAll(nodeFs);
+
+    /**
+     *
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function ArpPollerService() {
+        this.pollIntervalMs = 1000;
+        this.last = [];
+        this.current = [];
+    }
+
+    ArpPollerService.prototype.parseArpCache = function() {
+        return fs.readFileAsync('/proc/net/arp')
+        .then(function(data) {
+            var cols, lines, entries = [];
+            lines = data.toString().split('\n');
+            _.forEach(lines, function(line, index) {
+                if(index !== 0) {
+                    cols = line.replace(/ [ ]*/g, ' ').split(' ');
+                    if((cols.length > 3) && 
+                       (cols[0].length !== 0) && 
+                       (cols[3].length !== 0)) {
+                        entries.push({ 
+                            ip: cols[0], 
+                            mac: cols[3], 
+                            iface: cols[5], 
+                            flag: cols[2]
+                        });
+                    }
+                }
+            });
+            return entries;
+        })
+        .catch(function(err) {
+            logger.error('ARP Read Error', {error:err});
+            throw err;
+        });
+    };
+    
+    ArpPollerService.prototype.arpCacheHandler = function() {
+        var self = this;
+        return self.parseArpCache()
+        .then(function(data) {
+            self.current = data;
+            var updated = _.merge(_(self.last)
+            .filter(function(e) {
+                return _.isUndefined(_.find(self.current, e));
+            })
+            .value(), _(self.current)
+            .filter(function(e) {
+                return _.isUndefined(_.find(self.last, e));
+            })
+            .value());
+                        
+            if(updated.length) {
+                return Promise.map(updated, function(entry) {
+                    if(entry.flag === '0x0') {  // incomplete or removed entry
+                        logger.debug('Remove Lookup', {entry:entry});
+                        // Just invalidate the IP to preserve the MAC to nodeId mapping
+                        return waterline.lookups.setIp(null, entry.mac);
+                    } else { // set static or dynamic entry
+                        logger.debug('Add/Update Lookup', {entry:entry});
+                        return waterline.lookups.setIp(entry.ip, entry.mac);
+                    }
+                });
+            }
+        })
+        .catch(function(error) {
+            logger.error('Error Handling ARP Entry', {error:error});
+            throw error;
+        })
+        .finally(function() {
+            self.last = self.current;
+        });
+    };
+    
+
+    /**
+     * @memberOf ArpPollerService
+     */
+    ArpPollerService.prototype._run = function() {
+        var self = this;
+        this.subscription = Rx.Observable.interval(self.pollIntervalMs)
+        .subscribe(
+            self.arpCacheHandler.bind(self),
+            function(error) {
+                logger.error('ARP Poller Error', {error:error});
+            }
+        );
+    };
+    
+    ArpPollerService.prototype.start = Promise.method(function() {
+        if(configuration.get('arpPollerEnabled', true)) {
+            this._run();
+        }
+        return;
+    });
+    
+    ArpPollerService.prototype.stop = Promise.method(function() {
+        if(this.subscription) {
+            this.subscription.dispose();
+            this.subscription = undefined;
+        }
+        return;
+    });
+
+    return new ArpPollerService();
+}

--- a/spec/lib/common/encryption-spec.js
+++ b/spec/lib/common/encryption-spec.js
@@ -80,7 +80,6 @@ describe('Encryption', function () {
             it('should generate correct hash header', function() {
                 expect(this.subject.createHash('123ABCDEFG__zyz', 'sha512')).to.match(/^\$6\$*/);
                 expect(this.subject.createHash('pbefEFGA_98012-', 'sha256')).to.match(/^\$5\$*/);
-                expect(this.subject.createHash('1fj14LJA1Lk-?!k', 'md5')).to.match(/^\$1\$*/);
             });
 
             it('should generate correct hash data', function() {
@@ -89,8 +88,6 @@ describe('Encryption', function () {
                     .should.equal('$6$WeJknBPkDab$yRRWg5Kr1MCAbKkBtKyKtldb9DFDXidKHj.wQwOKO1TSHUKCvIi7x9QubOenwGfYXoBK0vvwKvNgIlW9Oc6O4.'); //jshint ignore:line
                 this.subject.createHash(data, 'sha256', '$5$WeJknBPkDab')
                     .should.equal('$5$WeJknBPkDab$t4J3IF.tD9H/2HFDjV.CpFN1ay5rmwa7maVkstEiyv9');
-                this.subject.createHash(data, 'md5', '$1$WeJknBPkDab')
-                    .should.equal('$1$WeJknBPk$t3LdooA1UatyI0C7pGX5F/');
             });
         });
 

--- a/spec/lib/services/arp-poller-spec.js
+++ b/spec/lib/services/arp-poller-spec.js
@@ -1,0 +1,118 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('ARP Poller Service', function () {
+    var fs;
+    var waterline = {};
+    var rx = {};
+    var service;
+    var procData = "IP address   HW type   Flags    HW address            Mask   Device\n" +
+                   "1.2.3.4      0x1       0x2      52:54:be:ef:ff:12     *      eth1\n" +
+                   "2.3.4.5      0x1       0x2      00:00:be:ef:ff:00     *      eth0\n" +
+                   "2.3.4.6      0x1       0x2      00:00:be:ef:ff:01     *      eth0\n";
+    
+    var parsedData = [
+        { ip:'1.2.3.4', mac:'52:54:be:ef:ff:12', iface:'eth1', flag:'0x2' },
+        { ip:'2.3.4.5', mac:'00:00:be:ef:ff:00', iface:'eth0', flag:'0x2' },
+        { ip:'2.3.4.6', mac:'00:00:be:ef:ff:01', iface:'eth0', flag:'0x2' }
+    ];
+           
+    helper.before();
+         
+    before(function () {
+        helper.setupInjector([
+            helper.di.simpleWrapper(waterline,'Services.Waterline'),
+            helper.di.simpleWrapper(rx,'Rx')
+        ]);
+
+        waterline.lookups = {
+            setIp: sinon.stub().resolves()
+        };
+        
+        rx.Observable = {
+            interval: sinon.stub().returns({
+                subscribe: sinon.stub().returns({
+                    dispose: sinon.stub().resolves()
+                })
+            })
+        };
+        
+        service = helper.injector.get('Services.ArpPoller');
+        fs = helper.injector.get('fs');
+        sinon.stub(fs, 'readFileAsync');
+    });
+
+    helper.after(function() {
+        fs.readFileAsync.restore();
+    });
+    
+    beforeEach(function() {
+        fs.readFileAsync.reset();
+        waterline.lookups.setIp.reset();
+    });
+
+    describe("ARP poller methods", function(){
+        it('should start the service', function() {
+            return service.start()
+            .then(function() {
+                expect(service.subscription).to.be.fullfilled;
+            });
+        });
+        
+        it('should stop the service', function() {
+            return service.stop()
+            .then(function() {
+                expect(service.subscription).to.equal(undefined);
+            });
+        });
+                
+        it('should parse ARP data', function() {
+            fs.readFileAsync.resolves(procData);
+            return service.parseArpCache()
+            .then(function(parsed) {
+                expect(parsed).to.deep.equal(parsedData);
+            });
+        });
+        
+        it('should parse ARP data with error', function() {
+            fs.readFileAsync.rejects('error');
+            return expect(service.parseArpCache()).to.be.rejectedWith('error');
+        });
+        
+        it('should handle initial ARP data', function() {
+            fs.readFileAsync.resolves(procData);
+            service.last = { ip:'1.2.3.4', mac:'52:54:be:ef:ff:12', iface:'eth1', flag:'0x2' };
+            return service.arpCacheHandler()
+            .then(function() {
+                expect(service.last).to.deep.equal(parsedData);
+                expect(service.current).to.deep.equal(parsedData);
+            });
+        });
+
+        it('should handle updated ARP data', function() {
+            fs.readFileAsync.resolves(
+                "IP address  HW type  Flags   HW address         Mask  Device\n" +
+                "1.2.3.4     0x1      0x0     52:54:be:ef:ff:12  *     eth1\n" +
+                "2.3.4.5     0x1      0x0     00:00:be:ef:ff:00  *     eth0\n" +
+                "2.3.4.9     0x1      0x2     00:00:be:ef:ff:01  *     eth0\n"
+            );
+            parsedData[0].flag = '0x0';
+            parsedData[1].flag = '0x0';
+            parsedData[2].ip = '2.3.4.9';
+            return service.arpCacheHandler()
+            .then(function() {
+                expect(waterline.lookups.setIp).to.be.calledThrice;
+                expect(service.last).to.deep.equal(parsedData);
+                expect(service.current).to.deep.equal(parsedData);
+            });
+        });
+        
+        it('should handle ARP data with error', function() {
+            fs.readFileAsync.rejects('error');
+            return expect(service.arpCacheHandler()).to.be.rejectedWith('error');
+        });
+        
+    });
+});


### PR DESCRIPTION
This moves the on-taskgraph ARP poller job to on-core services with `ArpPollerEnable` config option to disable/enable.

This also addresses a unit-test failure with apache-crypt package change removing MD5 hashing

@RackHD/corecommitters @uppalk1 @zyoung51 @tannoa2 @keedya @tldavies 