### PR TITLE
[1.2.0-branch] locking version of apache-crypt to be 1.0.9 to fix on-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "always-tail": "^0.1.1",
     "amqp": "^0.2.3",
     "anchor": "^0.10.2",
-    "apache-crypt": "^1.0.9",
+    "apache-crypt": "1.0.9",
     "assert-plus": "^1.0.0",
     "bluebird": "^2.8.0",
     "colors": "^1.0.3",


### PR DESCRIPTION
This is the same PR to https://github.com/RackHD/on-core/pull/139 but for the release/1.2.0-branch