### PR TITLE
Move ARP handler into lookups service

### DIFF
--- a/lib/common/arp.js
+++ b/lib/common/arp.js
@@ -1,0 +1,108 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = arpCacheFactory;
+arpCacheFactory.$provide = 'ARPCache';
+arpCacheFactory.$inject = [
+    'Logger',
+    'Promise',
+    'Assert',
+    'Util',
+    '_',
+    'fs'
+];
+
+function arpCacheFactory(
+    Logger,
+    Promise,
+    assert,
+    util,
+    _,
+    nodeFs
+) {
+    var logger = Logger.initialize(arpCacheFactory);
+    var fs = Promise.promisifyAll(nodeFs);
+
+    /**
+     *
+     * @param {Object} options
+     * @param {Object} context
+     * @param {String} taskId
+     * @constructor
+     */
+    function ARPCache() {
+        this.last = [];
+        this.current = [];
+    }
+
+    ARPCache.prototype.parseArpCache = function() {
+        return fs.readFileAsync('/proc/net/arp')
+        .then(function(data) {
+            var cols, lines, entries = [];
+            lines = data.toString().split('\n');
+            _.forEach(lines, function(line, index) {
+                if(index !== 0) {
+                    cols = line.replace(/ [ ]*/g, ' ').split(' ');
+                    if((cols.length > 3) && 
+                       (cols[0].length !== 0) && 
+                       (cols[3].length !== 0)) {
+                        entries.push({ 
+                            ip: cols[0], 
+                            mac: cols[3], 
+                            iface: cols[5], 
+                            flag: cols[2]
+                        });
+                    }
+                }
+            });
+            return entries;
+        })
+        .catch(function(err) {
+            logger.error('ARP Read Error', {error:err});
+            throw err;
+        });
+    };
+    
+    ARPCache.prototype.getCurrent = function() {
+        var self = this;
+        return self.parseArpCache()
+        .then(function(data) {
+            self.current = data;
+            var updated = _.merge(_(self.last)
+            .filter(function(e) {
+                return _.isUndefined(_.find(self.current, e));
+            })
+            .value(), _(self.current)
+            .filter(function(e) {
+                return _.isUndefined(_.find(self.last, e));
+            })
+            .value());
+                        
+            if(updated.length) {
+                return Promise.map(updated, function(entry) {
+                    if(entry.flag !== '0x0') { 
+                        return { 
+                            ip: entry.ip, 
+                            mac: entry.mac 
+                        };
+                    }
+                });
+            }
+        })
+        .then(function(entries) {
+            return _(entries).filter(function(entry) {
+                return entry;
+            }).value();
+        })
+        .catch(function(error) {
+            logger.error('Error Handling ARP Entry', {error:error});
+            throw error;
+        })
+        .finally(function() {
+            self.last = self.current;
+        });
+    };
+    
+    return new ARPCache();
+}

--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -7,19 +7,19 @@ module.exports = lookupServiceFactory;
 lookupServiceFactory.$provide = 'Services.Lookup';
 lookupServiceFactory.$inject = [
     'Promise',
-    'Services.Configuration',
     'Services.Waterline',
+    'Services.Configuration',
     'Assert',
     'Errors',
     '_',
-    'lru-cache'
+    'lru-cache',
+    'ARPCache'
 ];
 
 /**
  * Provides a LookupService singleton.
  * @private
  * @param  {Promise} Promise
- * @param  {configuration} configuration
  * @param  {Waterline} waterline
  * @param  {Assert} assert
  * @param  {Errors} errors
@@ -30,12 +30,13 @@ lookupServiceFactory.$inject = [
  */
 function lookupServiceFactory(
     Promise,
-    configuration,
     waterline,
+    configuration,
     assert,
     Errors,
     _,
-    LRU
+    LRU,
+    arpCache
 ) {
     // TODO: stolen from http-service could stand to be a re-usable helper.
     /**
@@ -211,9 +212,11 @@ function lookupServiceFactory(
      */
     LookupService.prototype.ipAddressToMacAddress = function (ip) {
         assert.isIP(ip);
-
-        return waterline.lookups.findOneByTerm(ip).then(function (record) {
-            return record.macAddress;
+        return this.validateArpCache()
+        .then(function() {
+            return waterline.lookups.findOneByTerm(ip).then(function (record) {
+                return record.macAddress;
+            });
         });
     };
 
@@ -244,15 +247,18 @@ function lookupServiceFactory(
      * correlates to the provided MAC Address.
      */
     LookupService.prototype.macAddressToIp = function (macAddress) {
-        return waterline.lookups.findOneByTerm(macAddress).then(function (record) {
-            if (record.ipAddress) {
-                return record.ipAddress;
-            } else {
-                throw new Errors.NotFoundError(
-                    'Lookup Record Not Found (macAddressToIp)',
-                    record
-                );
-            }
+        return this.validateArpCache()
+        .then(function() {
+            return waterline.lookups.findOneByTerm(macAddress).then(function (record) {
+                if (record.ipAddress) {
+                    return record.ipAddress;
+                } else {
+                    throw new Errors.NotFoundError(
+                        'Lookup Record Not Found (macAddressToIp)',
+                        record
+                    );
+                }
+            });
         });
     };
 
@@ -266,26 +272,27 @@ function lookupServiceFactory(
      * correlates to the provided MAC Address.
      */
     LookupService.prototype.macAddressToNodeId = function (macAddress) {
-        var cachePromise = this.checkNodeIdCache(macAddress);
+        var self = this;
+        var cachePromise = self.checkNodeIdCache(macAddress);
 
         if (cachePromise) {
             return cachePromise;
         }
-
-        return waterline.lookups.findOneByTerm(macAddress).then(function (record) {
+        
+        return waterline.lookups.findOneByTerm(macAddress)
+        .then(function (record) {
             if (record.node) {
-                return this.assignNodeIdCache(macAddress, record.node);
+                return self.assignNodeIdCache(macAddress, record.node);
             }
-
             else {
-                this.clearNodeIdCache(macAddress);
-
+                self.clearNodeIdCache(macAddress);
                 throw new Errors.NotFoundError(
                     'Lookup Record Not Found (macAddressToNodeId)',
                     record
                 );
             }
-        }.bind(this)).catch(this.clearNodeIdCacheAndThrow.bind(this, macAddress));
+        })
+        .catch(self.clearNodeIdCacheAndThrow.bind(self, macAddress));
     };
 
     /**
@@ -297,16 +304,19 @@ function lookupServiceFactory(
      */
     LookupService.prototype.ipAddressToNode = function (ip) {
         assert.isIP(ip);
-
-        return waterline.lookups.findOneByTerm(ip).then(function (record) {
-            if (record.node) {
-                return waterline.nodes.needOneById(record.node);
-            } else {
-                throw new Errors.NotFoundError(
-                    'Lookup Record Not Found (ipAddressToNode)',
-                    record
-                );
-            }
+        
+        return this.validateArpCache()
+        .then(function() {
+            return waterline.lookups.findOneByTerm(ip).then(function (record) {
+                if (record.node) {
+                    return waterline.nodes.needOneById(record.node);
+                } else {
+                    throw new Errors.NotFoundError(
+                        'Lookup Record Not Found (ipAddressToNode)',
+                        record
+                    );
+                }
+            });
         });
     };
 
@@ -321,27 +331,29 @@ function lookupServiceFactory(
      */
     LookupService.prototype.ipAddressToNodeId = function (ip) {
         assert.isIP(ip);
-
-        var cachePromise = this.checkNodeIdCache(ip);
-
+        
+        var self = this;
+        var cachePromise = self.checkNodeIdCache(ip);
         if (cachePromise) {
             return cachePromise;
         }
-
-        return waterline.lookups.findOneByTerm(ip).then(function (record) {
-            if (record.node) {
-                return this.assignNodeIdCache(ip, record.node);
-            }
-
-            else {
-                this.clearNodeIdCache(ip);
-
-                throw new Errors.NotFoundError(
-                    'Lookup Record Not Found (ipAddressToNodeId)',
-                    record
-                );
-            }
-        }.bind(this)).catch(this.clearNodeIdCacheAndThrow.bind(this, ip));
+        
+        return self.validateArpCache()
+        .then(function() {
+            return waterline.lookups.findOneByTerm(ip).then(function (record) {
+                if (record.node) {
+                    return self.assignNodeIdCache(ip, record.node);
+                }
+                else {
+                    self.clearNodeIdCache(ip);
+                    throw new Errors.NotFoundError(
+                        'Lookup Record Not Found (ipAddressToNodeId)',
+                        record
+                    );
+                }
+            })
+            .catch(self.clearNodeIdCacheAndThrow.bind(self, ip));
+        });
     };
 
     /**
@@ -351,16 +363,20 @@ function lookupServiceFactory(
      * IP Addresses associated with the Node.
      */
     LookupService.prototype.nodeIdToIpAddresses = function (id) {
+        var self = this;
         assert.isMongoId(id);
 
-        return waterline.lookups.findByTerm(id).then(function (records) {
-            return _.reduce(records, function (ipAddresses, record) {
-                if (record.ipAddress) {
-                    ipAddresses.push(record.ipAddress);
-                }
+        return self.validateArpCache()
+        .then(function() {
+            return waterline.lookups.findByTerm(id).then(function (records) {
+                return _.reduce(records, function (ipAddresses, record) {
+                    if (record.ipAddress) {
+                        ipAddresses.push(record.ipAddress);
+                    }
 
-                return ipAddresses;
-            }, []);
+                    return ipAddresses;
+                }, []);
+            });
         });
     };
 
@@ -383,6 +399,16 @@ function lookupServiceFactory(
     
     LookupService.prototype.setIpAddress = function (ip, mac) {
         return waterline.lookups.setIp(ip, mac);
+    };
+    
+    LookupService.prototype.validateArpCache = function () {
+        var self = this;
+        if(configuration.get('arpCacheEnabled', true)) {
+            return arpCache.getCurrent()
+            .map(function(entry) {
+                return self.setIpAddress(entry.ip, entry.mac);
+            });
+        }
     };
 
     LookupService.prototype.start = function () {

--- a/spec/lib/common/arp-spec.js
+++ b/spec/lib/common/arp-spec.js
@@ -1,0 +1,86 @@
+// Copyright 2016, EMC, Inc.
+
+
+'use strict';
+
+describe('ARPCache', function () {
+    var arpCache;
+    var fs;
+    var procData = "IP address   HW type   Flags    HW address            Mask   Device\n" +
+                   "1.2.3.4      0x1       0x2      52:54:be:ef:ff:12     *      eth1\n" +
+                   "2.3.4.5      0x1       0x2      00:00:be:ef:ff:00     *      eth0\n" +
+                   "2.3.4.6      0x1       0x2      00:00:be:ef:ff:01     *      eth0\n";
+    
+    var parsedData = [
+        { ip:'1.2.3.4', mac:'52:54:be:ef:ff:12', iface:'eth1', flag:'0x2' },
+        { ip:'2.3.4.5', mac:'00:00:be:ef:ff:00', iface:'eth0', flag:'0x2' },
+        { ip:'2.3.4.6', mac:'00:00:be:ef:ff:01', iface:'eth0', flag:'0x2' }
+    ];
+
+    helper.before();
+
+    before(function () {
+        arpCache = helper.injector.get('ARPCache');
+        fs = helper.injector.get('fs');
+        sinon.stub(fs, 'readFileAsync');
+    });
+
+    beforeEach(function() {
+        fs.readFileAsync.reset();
+    });
+
+    helper.after(function () {
+        fs.readFileAsync.restore();
+    });
+
+    describe("Handle ARP Entry", function(){
+        it('should parse ARP data', function() {
+            fs.readFileAsync.resolves(procData);
+            return arpCache.parseArpCache()
+            .then(function(parsed) {
+                expect(parsed).to.deep.equal(parsedData);
+            });
+        });
+        
+        it('should parse ARP data with error', function() {
+            fs.readFileAsync.rejects('error');
+            return expect(arpCache.parseArpCache()).to.be.rejectedWith('error');
+        });
+        
+        it('should handle initial ARP data', function() {
+            fs.readFileAsync.resolves(procData);
+            arpCache.last = {ip:'1.2.3.4', mac:'52:54:be:ef:ff:12', iface:'eth1', flag:'0x2'};
+            return arpCache.getCurrent()
+            .then(function() {
+                expect(arpCache.last).to.deep.equal(parsedData);
+                expect(arpCache.current).to.deep.equal(parsedData);
+            });
+        });
+
+        it('should handle updated ARP data', function() {
+            fs.readFileAsync.resolves(
+                "IP address  HW type  Flags   HW address         Mask  Device\n" +
+                "1.2.3.4     0x1      0x1     52:54:be:ef:ff:12  *     eth1\n" +
+                "2.3.4.5     0x1      0x0     00:00:be:ef:ff:00  *     eth0\n" +
+                "2.3.4.9     0x1      0x2     00:00:be:ef:ff:01  *     eth0\n"
+            );
+            parsedData[0].flag = '0x1';
+            parsedData[1].flag = '0x0';
+            parsedData[2].ip = '2.3.4.9';
+            return arpCache.getCurrent()
+            .then(function(data) {
+                expect(arpCache.last).to.deep.equal(parsedData);
+                expect(arpCache.current).to.deep.equal(parsedData);
+                expect(data).to.deep.equal([
+                    {ip:'1.2.3.4', mac:'52:54:be:ef:ff:12'},
+                    {ip:'2.3.4.9', mac:'00:00:be:ef:ff:01'}
+                ]);
+            });
+        });
+        
+        it('should handle ARP data with error', function() {
+            fs.readFileAsync.rejects('error');
+            return expect(arpCache.getCurrent()).to.be.rejectedWith('error');
+        });
+    });
+});


### PR DESCRIPTION
Moves the ARP handler into the lookups services deprecating ARP poller in on-taskgraph.  

Solves a couple known issues with existing ARP poller design:
1. Potential race condition when issuing a POST to /lookups on an IP change,  current ARP poller may see the ARP entry update and update the entry resulting in 500 response on the POST.
2. The existing poller runs as a job in on-taskgraph creating the prerequisite to run on-taskgraph on the same host that is taking the IP request from a client to ensure the hosts ARP table is current.  

@RackHD/corecommitters @uppalk1 @zyoung51 @tannoa2 @keedya 