### PR TITLE
add constants for drive secure erase

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -300,12 +300,32 @@ function constantsFactory (path) {
             Enclosure: 'enclosure'
         },
         Redfish: {
-            EventTypes: { 
+            EventTypes: {
                 StatusChange: 'StatusChange',
                 ResourceUpdated: 'ResourceUpdated',
                 ResourceAdded: 'ResourceAdded',
                 ResourceRemoved: 'ResourceRemoved',
                 Alert: 'Alert'
+            }
+        },
+        SecureErase: {
+            hdparm: {
+                protocol: ['SATADOM', 'SATA'],
+                args: ['secure-erase', 'secure-erase-enhanced']
+            },
+            sg_sanitize: { //jshint ignore:line
+                protocol: ['SAS'],
+                args: ['block', 'crypto', 'fail']
+            },
+            sg_format: { //jshint ignore:line
+                protocol: ['SAS'],
+                args: ['0', '1']
+            },
+            scrub: {
+                protocol: undefined,
+                args: ['nnsa', 'dod', 'fillzero', 'random', 'random2', 'fillff', 'gutmann',
+                    'schneier', 'fastold', 'pfitzner7', 'pfitzner33', 'usarmy', 'old', 'fastold',
+                    'custom=string']
             }
         }
     });


### PR DESCRIPTION
The tools and corresponding parameters (named "operation" here) varies for different type of drive's protocols. This PR adds support list about the relationship of "tool - protocol - operation".

Related PR:
https://github.com/RackHD/on-tasks/pull/225