### PR TITLE
Fix collection.publishRecord when called without a record

### DIFF
--- a/lib/common/model.js
+++ b/lib/common/model.js
@@ -60,10 +60,10 @@ function ModelFactory (
         },
 
         publishRecord: function (event, record, id) {
-          if (!id && this.attributes.instanceId) {
-              id = record.instanceId;
-          }
-          return waterlineProtocol.publishRecord(this, event, record, id);
+            if (!id && this.attributes && this.attributes.instanceId) {
+                id = record && record.instanceId;
+            }
+            return waterlineProtocol.publishRecord(this, event, record || {}, id || '');
         },
 
         afterCreate: function (record, next) {

--- a/spec/lib/common/model-spec.js
+++ b/spec/lib/common/model-spec.js
@@ -51,7 +51,6 @@ describe('Model', function () {
     describe('newly created record', function () {
         var record;
 
-
         before('reset DB collections', function () {
             return helper.reset();
         });
@@ -287,7 +286,6 @@ describe('Model', function () {
             });
         });
     });
-
 
     describe('model destroying', function () {
         var record;
@@ -542,32 +540,50 @@ describe('Model', function () {
           });
     });
 
-    describe('publishRecord() failure', function () {
+    describe('publishRecord', function () {
         beforeEach('set up mocks', function () {
             waterlineProtocol.publishRecord = sinon.stub().returns(bluebird.resolve());
         });
 
-        it('should cause rejection on create()', function () {
-            var error = new Error();
-            waterlineProtocol.publishRecord = sinon.stub().returns(bluebird.reject(error));
-            return waterline.testobjects.create({})
-            .should.be.rejected.and.eventually.have.property('originalError', error);
+        describe('helper method', function () {
+            it('should call waterlineProtocol.publishrecord', function () {
+                waterline.testobjects.publishRecord.call('this', 'event', 'record', 'id');
+                expect(waterlineProtocol.publishRecord).to.have.been.calledOnce;
+                expect(waterlineProtocol.publishRecord).to.have.been.calledWith(
+                    'this', 'event', 'record', 'id');
+            });
+
+            it('should not fail if record is null', function () {
+                waterline.testobjects.publishRecord.call('this', 'event', null, null);
+                expect(waterlineProtocol.publishRecord).to.have.been.calledOnce;
+                expect(waterlineProtocol.publishRecord).to.have.been.calledWith(
+                    'this', 'event', {}, '');
+            });
         });
 
-        it('should cause rejection on update()', function () {
-            var error = new Error();
-            return waterline.testobjects.create({}).then(function (record) {
+        describe('failure', function () {
+            it('should cause rejection on create()', function () {
+                var error = new Error();
                 waterlineProtocol.publishRecord = sinon.stub().returns(bluebird.reject(error));
-                return waterline.testobjects.update(record.id, { dummy: 'test' });
-            }).should.be.rejected.and.eventually.have.property('originalError', error);
-        });
+                return waterline.testobjects.create({})
+                .should.be.rejected.and.eventually.have.property('originalError', error);
+            });
 
-        it('should cause rejection on destroy()', function () {
-            var error = new Error();
-            return waterline.testobjects.create({}).then(function (record) {
-                waterlineProtocol.publishRecord = sinon.stub().returns(bluebird.reject(error));
-                return waterline.testobjects.destroy(record.id);
-            }).should.be.rejected.and.eventually.have.property('originalError', error);
+            it('should cause rejection on update()', function () {
+                var error = new Error();
+                return waterline.testobjects.create({}).then(function (record) {
+                    waterlineProtocol.publishRecord = sinon.stub().returns(bluebird.reject(error));
+                    return waterline.testobjects.update(record.id, { dummy: 'test' });
+                }).should.be.rejected.and.eventually.have.property('originalError', error);
+            });
+
+            it('should cause rejection on destroy()', function () {
+                var error = new Error();
+                return waterline.testobjects.create({}).then(function (record) {
+                    waterlineProtocol.publishRecord = sinon.stub().returns(bluebird.reject(error));
+                    return waterline.testobjects.destroy(record.id);
+                }).should.be.rejected.and.eventually.have.property('originalError', error);
+            });
         });
     });
 


### PR DESCRIPTION
Prevents an exception from being thrown when the record is falsy.

```
6:47:14 PM graph.1 |  [error] [2016-06-07T18:47:14.703Z] [on-taskgraph] [TaskGraph.CompletedTaskPoller] [Server] Error handling potential finished graphs
6:47:14 PM graph.1 |   -> /lib/completed-task-poller.js:257
6:47:14 PM graph.1 |  error:
6:47:14 PM graph.1 |  stack:
6:47:14 PM graph.1 |    """
6:47:14 PM graph.1 |      TypeError: Cannot read property 'instanceId' of null
6:47:14 PM graph.1 |          at ModelFactory.Waterline.Collection.extend.publishRecord (/home/vagrant/src/on-taskgraph/node_modules/on-core/lib/common/model.js:64:26)
6:47:14 PM graph.1 |          at Object.exports.publishGraphRecord (/home/vagrant/src/on-taskgraph/node_modules/on-core/lib/workflow/stores/mongo.js:26:39)
6:47:14 PM graph.1 |          at /home/vagrant/src/on-taskgraph/node_modules/on-core/lib/workflow/stores/mongo.js:61:25
6:47:14 PM graph.1 |          at Object.tapHandler (/home/vagrant/src/on-taskgraph/node_modules/bluebird/js/main/finally.js:64:23)
6:47:14 PM graph.1 |          at Object.tryCatcher (/home/vagrant/src/on-taskgraph/node_modules/bluebird/js/main/util.js:26:23)
6:47:14 PM graph.1 |          at Promise._settlePromiseFromHandler (/home/vagrant/src/on-taskgraph/node_modules/bluebird/js/main/promise.js:507:31)
6:47:14 PM graph.1 |          at Promise._settlePromiseAt (/home/vagrant/src/on-taskgraph/node_modules/bluebird/js/main/promise.js:581:18)
6:47:14 PM graph.1 |          at Promise._settlePromises (/home/vagrant/src/on-taskgraph/node_modules/bluebird/js/main/promise.js:697:14)
6:47:14 PM graph.1 |          at Async._drainQueue (/home/vagrant/src/on-taskgraph/node_modules/bluebird/js/main/async.js:123:16)
6:47:14 PM graph.1 |          at Async._drainQueues (/home/vagrant/src/on-taskgraph/node_modules/bluebird/js/main/async.js:133:10)
6:47:14 PM graph.1 |          at Immediate.Async.drainQueues [as _onImmediate] (/home/vagrant/src/on-taskgraph/node_modules/bluebird/js/main/async.js:15:14)
6:47:14 PM graph.1 |          at processImmediate [as _immediateCallback] (timers.js:383:17)
6:47:14 PM graph.1 |    """
```