### PR TITLE
Node discovered alert

### DIFF
--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -227,5 +227,16 @@ function eventsProtocolFactory (Constants, messenger, assert) {
         );
     };
 
+    EventsProtocol.prototype.publishNodeAlert = function (nodeId, data) {
+        assert.string(nodeId);
+        assert.object(data);
+
+        return messenger.publish(
+            Constants.Protocol.Exchanges.Events.Name,
+            'node.alert' + '.' + nodeId,
+            data || {}
+        );
+    };
+
     return new EventsProtocol();
 }


### PR DESCRIPTION
one part of spec https://github.com/RackHD/RackHD/wiki/proposal-AMQP-notifications-on-node-discovery-or-inaccessibility, node remove and inaccessible alert will be in a following PR
the alert publish method will also be used for node removed and inaccessible or other node's state in future

related PRs:
https://github.com/RackHD/on-tasks/pull/240
https://github.com/RackHD/on-taskgraph/pull/121

@RackHD/corecommitters @iceiilin @WangWinson 