### PR TITLE
Create JsonSchemaValidator using Ajv lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function (di, directory) {
             helper.requireWrapper('pluralize', 'pluralize'),
             helper.requireWrapper('always-tail', 'Tail'),
             helper.requireWrapper('flat', 'flat'),
-            helper.requireWrapper('ajv', 'ajv'),
+            helper.requireWrapper('ajv', 'Ajv'),
 
             // Glob Requirables
             helper.requireGlob(__dirname + '/lib/common/*.js'),

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ module.exports = function (di, directory) {
             helper.requireWrapper('pluralize', 'pluralize'),
             helper.requireWrapper('always-tail', 'Tail'),
             helper.requireWrapper('flat', 'flat'),
+            helper.requireWrapper('ajv', 'ajv'),
 
             // Glob Requirables
             helper.requireGlob(__dirname + '/lib/common/*.js'),

--- a/lib/common/json-schema-validator.js
+++ b/lib/common/json-schema-validator.js
@@ -6,14 +6,14 @@ module.exports = jsonSchemaValidatorFactory;
 
 jsonSchemaValidatorFactory.$provide = 'JsonSchemaValidator';
 jsonSchemaValidatorFactory.$inject = [
-    'ajv'
+    'Ajv'
 ];
 
 function jsonSchemaValidatorFactory(
     Ajv
 ) {
-    function JsonSchemaValidator () {
-        this._ajv = new Ajv({ allErrors: true,  verbose: true});
+    function JsonSchemaValidator(options) {
+        this._ajv = new Ajv(options || {});
         this.addSchema = this._ajv.addSchema;
         this.addMetaSchema = this._ajv.addMetaSchema;
     }
@@ -28,7 +28,7 @@ function jsonSchemaValidatorFactory(
         if (this._ajv.validate(schema, data)) {
             return true;
         } else {
-            var err = new Error('JSON schema validtion failed - ' + this._ajv.errorsText());
+            var err = new Error('JSON schema validation failed - ' + this._ajv.errorsText());
             err.errorList = this._ajv.errors;
             throw err;
         }
@@ -36,7 +36,7 @@ function jsonSchemaValidatorFactory(
 
     /**
      * Get compiled schema from the instance by `key` or `ref`.
-     * @param  {String} keyRef `key` that was passed to `addSchema` or 
+     * @param  {String} key `key` that was passed to `addSchema` or
      *                  full schema reference (`schema.id` or resolved id).
      * @return {Object} schema
      */

--- a/lib/common/json-schema-validator.js
+++ b/lib/common/json-schema-validator.js
@@ -1,0 +1,51 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = jsonSchemaValidatorFactory;
+
+jsonSchemaValidatorFactory.$provide = 'JsonSchemaValidator';
+jsonSchemaValidatorFactory.$inject = [
+    'ajv'
+];
+
+function jsonSchemaValidatorFactory(
+    Ajv
+) {
+    function JsonSchemaValidator () {
+        this._ajv = new Ajv({ allErrors: true,  verbose: true});
+        this.addSchema = this._ajv.addSchema;
+        this.addMetaSchema = this._ajv.addMetaSchema;
+    }
+
+    /**
+     * validate JSON data with given JSON schema
+     * @param  {Object|String} schema  JSON schema Object or schema ref id
+     * @param  {Object} data  JSON data to be validated
+     * @return {Boolean} validation pass or throw error
+     */
+    JsonSchemaValidator.prototype.validate = function (schema, data) {
+        if (this._ajv.validate(schema, data)) {
+            return true;
+        } else {
+            var err = new Error('JSON schema validtion failed - ' + this._ajv.errorsText());
+            err.errorList = this._ajv.errors;
+            throw err;
+        }
+    };
+
+    /**
+     * Get compiled schema from the instance by `key` or `ref`.
+     * @param  {String} keyRef `key` that was passed to `addSchema` or 
+     *                  full schema reference (`schema.id` or resolved id).
+     * @return {Object} schema
+     */
+    JsonSchemaValidator.prototype.getSchema = function (key) {
+        var schemaCompiled = this._ajv.getSchema(key);
+        if (schemaCompiled) {
+            return schemaCompiled.schema;
+        }
+    };
+
+    return JsonSchemaValidator;
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/RackHD/on-core",
   "dependencies": {
+    "ajv": "^4.1.0",
     "always-tail": "^0.2.0",
     "amqp": "0.2.3",
     "anchor": "^0.10.2",

--- a/spec/lib/common/json-schema-validator-spec.js
+++ b/spec/lib/common/json-schema-validator-spec.js
@@ -1,0 +1,47 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('JsonSchemaValidator', function () {
+    var validator;
+    var testSchema1 = { 
+        properties: {
+            repo: {
+                type: 'string',
+                format: 'uri'
+            }
+        }
+    };
+
+    helper.before();
+
+    before(function() {
+        var JsonSchemaValidator = helper.injector.get('JsonSchemaValidator');
+        validator = new JsonSchemaValidator();
+    });
+
+    it('should return true when validation pass', function () {
+        var result = validator.validate(testSchema1, { repo : '/172.31.128.1/mirrors' });
+        expect(result).to.be.true;
+    });
+
+    it('should throw validation error with incorrect data format', function () {
+        expect(function () {
+            validator.validate(testSchema1, { repo : 'abc' });
+        }).to.throw(/JSON schema validtion failed/);
+    });
+
+    it('should add correct schema', function () {
+        testSchema1.id = 'test1';
+        expect(validator.addSchema(testSchema1)).to.be.empty;
+    });
+
+    it('should get existing schema', function () {
+        expect(validator.getSchema('test1')).to.deep.equal(testSchema1);
+    });
+
+    it('should not find schema not exist', function () {
+        expect(validator.getSchema('test2')).to.be.undefined;
+    });
+});
+

--- a/spec/lib/common/json-schema-validator-spec.js
+++ b/spec/lib/common/json-schema-validator-spec.js
@@ -4,6 +4,7 @@
 
 describe('JsonSchemaValidator', function () {
     var validator;
+    var JsonSchemaValidator;
     var testSchema1 = { 
         properties: {
             repo: {
@@ -13,12 +14,44 @@ describe('JsonSchemaValidator', function () {
         }
     };
 
+    var testRefSchema1 = {
+        id: '/refschema/r1',
+        definitions: {
+            url: {
+                type: 'string',
+                format: 'uri'
+            }
+        },
+        properties: {
+            repo: {
+                $ref: '#/definitions/url'
+            },
+            index: {
+                type: 'number',
+            }
+        }
+    };
+
+    var testRefSchema2 = {
+        id: '/refschema/r2',
+        properties: {
+            repo: {
+                $ref:'/refschema/r1#/definitions/url'
+            }
+        }
+    };
+
     helper.before();
 
     before(function() {
-        var JsonSchemaValidator = helper.injector.get('JsonSchemaValidator');
-        validator = new JsonSchemaValidator();
+        JsonSchemaValidator = helper.injector.get('JsonSchemaValidator');
     });
+
+    beforeEach(function() {
+        validator = new JsonSchemaValidator({allErrors: true, verbose: true});
+    });
+
+    helper.after();
 
     it('should return true when validation pass', function () {
         var result = validator.validate(testSchema1, { repo : '/172.31.128.1/mirrors' });
@@ -28,20 +61,36 @@ describe('JsonSchemaValidator', function () {
     it('should throw validation error with incorrect data format', function () {
         expect(function () {
             validator.validate(testSchema1, { repo : 'abc' });
-        }).to.throw(/JSON schema validtion failed/);
+        }).to.throw(/JSON schema validation failed/);
     });
 
     it('should add correct schema', function () {
-        testSchema1.id = 'test1';
-        expect(validator.addSchema(testSchema1)).to.be.empty;
+        expect(validator.addSchema(testSchema1, 'test1')).to.be.empty;
+        expect(validator.addSchema(testRefSchema1)).to.be.empty;
+        expect(validator.addSchema(testRefSchema2)).to.be.empty;
+    });
+
+    it('should throw error when add duplicated key', function () {
+        validator.addSchema(testSchema1, 'test1');
+        expect(function () {
+            validator.addSchema(testSchema1, 'test1');
+        }).to.throw(/schema with key or id "test1" already exists/);
     });
 
     it('should get existing schema', function () {
+        validator.addSchema(testSchema1, 'test1');
         expect(validator.getSchema('test1')).to.deep.equal(testSchema1);
     });
 
-    it('should not find schema not exist', function () {
+    it('should not find not existing schema', function () {
         expect(validator.getSchema('test2')).to.be.undefined;
+    });
+
+    it('should throw error when reference schema not added', function () {
+        validator.addSchema(testRefSchema2);
+        expect(function () {
+            validator.getSchema('/refschema/r2');
+        }).to.throw(/can't resolve reference /);
     });
 });
 


### PR DESCRIPTION
This is a base class for json schema validation.
As  @yyscamper 's design.
- Ajv library should be leveraged to validate JSON schema
- In this initial version, expose `validate`, `addSchema`, `getSchema` function
- Detail implement of skip `context` validate will be in the subclass in on-tasks

@RackHD/corecommitters