### PR TITLE
Update Task/TaskGraph AMQP messenger plugin to have big timeout.

### DIFF
--- a/HWIMO-TEST
+++ b/HWIMO-TEST
@@ -13,9 +13,9 @@ npm install
 ./node_modules/.bin/jshint -c .jshintrc lib index.js || true
 
 # run the tests without redirected output for debugging
-./node_modules/.bin/_mocha $(find spec -name '*-spec.js') --require spec/helper.js
+./node_modules/.bin/_mocha $(find spec -name '*-spec.js') --timeout 10000 --require spec/helper.js
 
 # Runs the mocha tests and reports the code coverage.
-./node_modules/.bin/istanbul cover -x "**/spec/**" ./node_modules/.bin/_mocha -- $(find spec -name '*-spec.js') -R xunit-file --require spec/helper.js
+./node_modules/.bin/istanbul cover -x "**/spec/**" ./node_modules/.bin/_mocha -- $(find spec -name '*-spec.js') --timeout 10000 -R xunit-file --require spec/helper.js
 ./node_modules/.bin/istanbul report cobertura
 


### PR DESCRIPTION
Based on the build machine, the Task/TaskGraph AMQP messenger plugin can take more than the default allotment of 2000ms.  The timeout was upped significantly to 20000ms.

Ran this on our local build machine that was experiencing the failures to verify.

@RackHD/corecommitters @benbp @jlongever @heckj