### PR TITLE
add getSchemaResolved function

### DIFF
--- a/lib/common/json-schema-validator.js
+++ b/lib/common/json-schema-validator.js
@@ -6,12 +6,16 @@ module.exports = jsonSchemaValidatorFactory;
 
 jsonSchemaValidatorFactory.$provide = 'JsonSchemaValidator';
 jsonSchemaValidatorFactory.$inject = [
-    'Ajv'
+    'Ajv',
+    '_'
 ];
 
 function jsonSchemaValidatorFactory(
-    Ajv
+    Ajv,
+    _
 ) {
+    var url = require('url');
+
     function JsonSchemaValidator(options) {
         this._ajv = new Ajv(options || {});
         this.addSchema = this._ajv.addSchema;
@@ -44,6 +48,101 @@ function jsonSchemaValidatorFactory(
         var schemaCompiled = this._ajv.getSchema(key);
         if (schemaCompiled) {
             return schemaCompiled.schema;
+        }
+    };
+
+    /**
+     * Get reference resolveed schema by `key`
+     * @param  {String} key `key` that was passed to `addSchema` or
+     *                  full schema reference (`schema.id` or resolved id).
+     * @return {Object} schema with reference resolved
+     */
+    JsonSchemaValidator.prototype.getSchemaResolved = function (key) {
+        var schemaCompiled = this._ajv.getSchema(key);
+        if (undefined === schemaCompiled) {
+            return;
+        }
+
+        if (_.isEmpty(schemaCompiled.refs)) {
+            return schemaCompiled.schema;
+        }
+
+        var resolvedValues = {};
+        resolveRef(schemaCompiled, resolvedValues);
+        var schemaResolved = _.cloneDeep(schemaCompiled.schema);
+        // replaced is an array will be pushed ref id when there is any $ref object 
+        // been replaced repeat replaceRefObj when replace real happened in last time,
+        // until all $ref object been replaced. Each replaceRefObj will cover the $ref
+        // in the same nest level (depth)
+        var replaced;
+        do {
+            replaced = [];
+            replaceRefObj(schemaResolved, resolvedValues, schemaResolved.id, replaced);
+        }
+        while (replaced.length > 0);
+
+        return schemaResolved;
+
+        // resolve reference recursively
+        // it search the compiled schema data structure from ajv.getSchema, find out 
+        // and store referenced value to resolvedValues map
+        function resolveRef(schemaObj, resolvedValues) {
+            // the array store referenced value
+            var refVal = schemaObj.refVal;
+            // the map store full ref id and index of the referenced value in refVal
+            // example: { 'test#definitions/option' : 1, 'test#definitions/repo' : 2 }
+            var refs = schemaObj.refs;
+            // the map to store schema value with sub reference
+            var subRefs = {};
+
+            _.forEach(refs, function (index, refId) {
+                // if reference id already resolved then continue the loop
+                if (refId in resolvedValues) {
+                    return true; // continue
+                }
+
+                var refValue = refVal[index];
+                // if no further nested reference, add to resolved map
+                if (_.isEmpty(refValue.refs)) {
+                    resolvedValues[refId] = refValue;
+                    return true;
+                }
+
+                // add schema value with sub reference to map to resolve later
+                subRefs[refId] = refValue;
+            });
+
+            // resolve sub reference recursively
+            _.forEach(subRefs, function (subRef, refId) {
+                resolvedValues[refId] = 1;
+                resolvedValues[refId] = resolveRef(subRef, resolvedValues);
+            });
+
+            return schemaObj.schema;
+        }
+
+        // replace reference in schema recursively
+        // it search the schema object and replace the $ref object with the real value
+        // example: { $ref: '#/definitions/test'} -> { type: 'string', format: 'uri'}
+        function replaceRefObj (obj, resolvedValues, baseId, replaced) {
+            if (!(obj instanceof Object)) {
+                return;
+            }
+
+            if (obj.$ref) {
+                var refId = url.resolve(baseId, obj.$ref);
+                if (refId in resolvedValues) {
+                    replaced.push(refId);
+                    return resolvedValues[refId];
+                }
+            }
+
+            for (var k in obj) {
+                var resolvedObj = replaceRefObj(obj[k], resolvedValues, baseId, replaced);
+                if (resolvedObj) {
+                    obj[k] = resolvedObj;
+                }
+            }
         }
     };
 

--- a/spec/lib/common/json-schema-validator-spec.js
+++ b/spec/lib/common/json-schema-validator-spec.js
@@ -41,6 +41,172 @@ describe('JsonSchemaValidator', function () {
         }
     };
 
+    var testRefSchema1Resolved = {
+        id: '/refschema/r1',
+        definitions: {
+            url: {
+                type: 'string',
+                format: 'uri'
+            }
+        },
+        properties: {
+            repo: {
+                type: 'string',
+                format: 'uri'
+            },
+            index: {
+                type: 'number',
+            }
+        }
+    };
+
+    var testRefSchema2Resolved = {
+        id: '/refschema/r2',
+        properties: {
+            repo: {
+                type: 'string',
+                format: 'uri'
+            }
+        }
+    };
+
+    var testRefSchema3 = {
+        "id": "/refschema/r3",
+        "definitions": {
+            "UserName": {
+                "description": "The user account name",
+                "type": "string",
+                "pattern": "^[A-Za-z0-9_]",
+                "minLength": 1
+            },
+            "UserPassword": {
+                "description": "The account password",
+                "type": "string",
+                "minLength": 5
+            },
+            "SshKey": {
+                "type": "string",
+                "description": "The trusted ssh key for the particular user",
+                "minLength": 1
+            },
+            "UserID": {
+                "description": "The unique user identifier for this user account",
+                "type": "integer",
+                "minimum": 500,
+                "maximum": 65535
+            },
+            "UserAccountInfoSimple": {
+                "type": "object",
+                "description": "The simple information for an user account",
+                "properties": {
+                    "name": {
+                        "$ref": "#/definitions/UserName"
+                    },
+                    "password": {
+                        "$ref": "#/definitions/UserPassword"
+                    },
+                    "sshKey": {
+                        "$ref": "#/definitions/SshKey"
+                    }
+                },
+                "required": ["name", "password"]
+            }
+        },
+        "properties": {
+            "UsersSimple": {
+                "description": "The list of user account created during OS installation",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "$ref": "#/definitions/UserAccountInfoSimple"
+                },
+                "uniqueItems": true
+            }
+        }
+    };
+
+    var testRefSchema3Resolved = {
+        "id": "/refschema/r3",
+        "definitions": {
+            "UserName": {
+                "description": "The user account name",
+                "type": "string",
+                "pattern": "^[A-Za-z0-9_]",
+                "minLength": 1
+            },
+            "UserPassword": {
+                "description": "The account password",
+                "type": "string",
+                "minLength": 5
+            },
+            "SshKey": {
+                "type": "string",
+                "description": "The trusted ssh key for the particular user",
+                "minLength": 1
+            },
+            "UserID": {
+                "description": "The unique user identifier for this user account",
+                "type": "integer",
+                "minimum": 500,
+                "maximum": 65535
+            },
+            "UserAccountInfoSimple": {
+                "type": "object",
+                "description": "The simple information for an user account",
+                "properties": {
+                    "name": {
+                        "description": "The user account name",
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_]",
+                        "minLength": 1
+                    },
+                    "password": {
+                        "description": "The account password",
+                        "type": "string",
+                        "minLength": 5
+                    },
+                    "sshKey": {
+                        "type": "string",
+                        "description": "The trusted ssh key for the particular user",
+                        "minLength": 1
+                    }
+                },
+                "required": ["name", "password"]
+            }
+        },
+        "properties": {
+            "UsersSimple": {
+                "description": "The list of user account created during OS installation",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "description": "The simple information for an user account",
+                    "properties": {
+                        "name": {
+                            "description": "The user account name",
+                            "type": "string",
+                            "pattern": "^[A-Za-z0-9_]",
+                            "minLength": 1
+                        },
+                        "password": {
+                            "description": "The account password",
+                            "type": "string",
+                            "minLength": 5
+                        },
+                        "sshKey": {
+                            "type": "string",
+                            "description": "The trusted ssh key for the particular user",
+                            "minLength": 1
+                        }
+                    },
+                    "required": ["name", "password"]
+                },
+                "uniqueItems": true
+            }
+        }
+    };
+
     helper.before();
 
     before(function() {
@@ -91,6 +257,19 @@ describe('JsonSchemaValidator', function () {
         expect(function () {
             validator.getSchema('/refschema/r2');
         }).to.throw(/can't resolve reference /);
+    });
+
+    it('should get schema with reference resolved', function () {
+        validator.addSchema(testRefSchema1);
+        validator.addSchema(testRefSchema2);
+        validator.addSchema(testRefSchema3);
+
+        expect(validator.getSchemaResolved('/refschema/r1'))
+            .to.deep.equal(testRefSchema1Resolved);
+        expect(validator.getSchemaResolved('/refschema/r2'))
+            .to.deep.equal(testRefSchema2Resolved);
+        expect(validator.getSchemaResolved('/refschema/r3'))
+            .to.deep.equal(testRefSchema3Resolved);
     });
 });
 


### PR DESCRIPTION
While `getSchema` function return the original schema added to the validator instance,
`getSchemaResolved` is to return a schema with reference resolved.
example:
```JSON
{
        "id": "/refschema/r1",
        "definitions": {
            "url": {
                "type": "string",
                "format": "uri"
            }
        },
        "properties“: {
            ”repo": {
                "$ref": "#/definitions/url"
            }
        }
};
``` 
after resolve
```JSON
{
        "id": "/refschema/r1",
        "definitions": {
            "url": {
                "type": "string",
                "format": "uri"
            }
        },
        "properties": {
            "repo": {
                "type": "string",
                "format": "uri"
            }
        }
};
```
 
@RackHD/corecommitters @cgx027 @iceiilin 