### PR TITLE
json-schema-validator: add validatePatternSkipped & reset function

### DIFF
--- a/lib/common/json-schema-validator.js
+++ b/lib/common/json-schema-validator.js
@@ -7,17 +7,20 @@ module.exports = jsonSchemaValidatorFactory;
 jsonSchemaValidatorFactory.$provide = 'JsonSchemaValidator';
 jsonSchemaValidatorFactory.$inject = [
     'Ajv',
+    'Assert',
     '_'
 ];
 
 function jsonSchemaValidatorFactory(
     Ajv,
+    assert,
     _
 ) {
     var url = require('url');
 
     function JsonSchemaValidator(options) {
-        this._ajv = new Ajv(options || {});
+        this.options = options || {};
+        this._ajv = new Ajv(this.options);
         this.addSchema = this._ajv.addSchema;
         this.addMetaSchema = this._ajv.addMetaSchema;
     }
@@ -34,6 +37,54 @@ function jsonSchemaValidatorFactory(
         } else {
             var err = new Error('JSON schema validation failed - ' + this._ajv.errorsText());
             err.errorList = this._ajv.errors;
+            throw err;
+        }
+    };
+
+    /**
+     * validate JSON data with given JSON schema and ignore some failure if the error matches some
+     * patterns.
+     *
+     * NOTE: this function depends on the option 'allErrors` and 'verbose' is enabled
+     *
+     * @param  {Object|String} schema - JSON schema Object or schema ref id
+     * @param  {Object} data - JSON data to be validated
+     * @param  {Regex|Array<Regex>} skipPatterns - The skip patterns, if any skip pattern is
+     * matched, that validation error will be ignored.
+     * @return {Boolean} true if validation passes, otherwise throw error
+     */
+    JsonSchemaValidator.prototype.validatePatternsSkipped = function (schema, data, skipPatterns) {
+        assert.equal(this.options.allErrors, true,
+                  "option 'allErrors' need be enabled for validatePatternSkipped");
+        assert.equal(this.options.verbose, true,
+                 "option 'verbose' need be enabled for validatePatternSkipped");
+
+        if (this._ajv.validate(schema, data)) {
+            return true;
+        }
+
+        var errors = this._ajv.errors;
+
+        if (skipPatterns) {
+            if (!_.isArray(skipPatterns)) {
+                skipPatterns = [skipPatterns];
+            }
+            assert.arrayOfRegexp(skipPatterns, 'skip pattern should be regexp');
+
+            //If any skip patter is matched, then that error will be skipped.
+            errors = _.filter(errors, function(error) {
+                return !_.some(skipPatterns, function(pattern) {
+                    var result = pattern.test(error.data + '');
+                    return result;
+                });
+            });
+        }
+
+        if (_.isEmpty(errors)) {
+            return true;
+        } else {
+            var err = new Error('JSON schema validation failed - ' + this._ajv.errorsText(errors));
+            err.errorList = errors;
             throw err;
         }
     };
@@ -144,6 +195,14 @@ function jsonSchemaValidatorFactory(
                 }
             }
         }
+    };
+
+    /**
+     * Reset JSON-Schema validator
+     * After reset, all added schemas and meta-schemas will be deleted.
+     */
+    JsonSchemaValidator.prototype.reset = function () {
+        this._ajv = new Ajv(this.options);
     };
 
     return JsonSchemaValidator;


### PR DESCRIPTION
add functions to json-schema-validator:

1 - `validatePatternSkipped`: validate the data against schema, but skip some validation if the error matches the skip-patterns. This is to support task schema upfront validation, which need to skip all context template.
2. `reset`: reset the validator to initial state.

@RackHD/corecommitters @WangWinson @iceiilin @cgx027 @pengz1 