### PR TITLE
Create alert for poller status changes

### DIFF
--- a/lib/models/work-item.js
+++ b/lib/models/work-item.js
@@ -82,7 +82,7 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                 type: 'boolean',
                 defaultsTo: false
             },
-            status:{
+            state:{
                 type: 'string',
                 defaultsTo: null
             },
@@ -151,16 +151,16 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
 
         setFailed: function setFailed(leaseToken, alertMessage, workItems) {
             var self = this;
-            var newStatus = "inaccessible";
+            var newState = "inaccessible";
             if (!Array.isArray(workItems)) {
                 workItems = Array.prototype.slice.call(arguments, 2);
             }
             var now = new Date();
             return Promise.all(_.map(workItems, function (workItem) {
                 if (!alertMessage) {
-                    newStatus = workItem.status;
-                } else {
-                    accessibleAlert(alertMessage, workItem, newStatus);
+                    newState = workItem.state;
+                } else if (! _.isEmpty(alertMessage)){
+                    accessibleAlert(alertMessage, workItem, newState);
                 }
                 return self.update({
                     id: workItem.id,
@@ -171,7 +171,7 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                     lastFinished: now,
                     leaseToken: null,
                     leaseExpires: null,
-                    status: newStatus
+                    state: newState
                 });
             })).then(function (workItems) {
                 return _.flattenDeep(workItems);
@@ -180,16 +180,16 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
 
         setSucceeded: function setSucceeded(leaseToken, alertMessage, workItems) {
             var self = this;
-            var newStatus = "accessible";
+            var newState = "accessible";
             if (!Array.isArray(workItems)) {
                 workItems = Array.prototype.slice.call(arguments, 2);
             }
             var now = new Date();
             return Promise.all(_.map(workItems, function (workItem) {
                 if (!alertMessage) {
-                    newStatus = workItem.status;
-                } else {
-                    accessibleAlert(alertMessage, workItem, newStatus);
+                    newState = workItem.state;
+                } else if (!_.isEmpty(alertMessage)){
+                    accessibleAlert(alertMessage, workItem, newState);
                 }
                 return self.update({
                     id: workItem.id,
@@ -200,7 +200,7 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                     lastFinished: now,
                     leaseToken: null,
                     leaseExpires: null,
-                    status: newStatus 
+                    state: newState 
                 });
             })).then(function (workItems) {
                 return _.flattenDeep(workItems);
@@ -266,21 +266,17 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
         return next();
     }
 
-    function accessibleAlert(alertMessage, workitem, status) {
-        assert.string(status);
-        if (workitem.status !== status) {
-            assert.object(alertMessage);
-            var alertInfo = _.assign(
-                {
-                    nodeId: workitem.node,
-                    status: status,
-                    pollerType: workitem.type,
-                    configure: workitem.config
-                },
-                alertMessage
-            );
-            return events.publishNodeAlert(workitem.node, alertInfo);
-        }
+    function accessibleAlert(alertMessage, workitem, state) {
+        assert.string(state);
+        assert.object(alertMessage);
+        var alertInfo = _.assign(
+            {
+                nodeId: workitem.node,
+                state: state
+            },
+            alertMessage
+        );
+        return events.publishNodeAlert(workitem.node, alertInfo);
     }
 
 }

--- a/lib/models/work-item.js
+++ b/lib/models/work-item.js
@@ -160,7 +160,7 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                 if (!alertMessage) {
                     newStatus = workItem.status;
                 } else {
-                    inaccessibleAlert(alertMessage, workItem);
+                    accessibleAlert(alertMessage, workItem, newStatus);
                 }
                 return self.update({
                     id: workItem.id,
@@ -189,7 +189,7 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                 if (!alertMessage) {
                     newStatus = workItem.status;
                 } else {
-                    accessibleAlert(alertMessage, workItem);
+                    accessibleAlert(alertMessage, workItem, newStatus);
                 }
                 return self.update({
                     id: workItem.id,
@@ -266,31 +266,17 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
         return next();
     }
 
-    function accessibleAlert(alertMessage, workitem) {
-        if (workitem.status !== "accessible") {
+    function accessibleAlert(alertMessage, workitem, status) {
+        assert.string(status);
+        if (workitem.status !== status) {
             assert.object(alertMessage);
             var alertInfo = _.assign(
                 {
                     nodeId: workitem.node,
-                    status: "accessible",
+                    status: status,
                     pollerType: workitem.type,
                     configure: workitem.config
                 },
-                alertMessage
-            );
-            return events.publishNodeAlert(workitem.node, alertInfo);
-        }
-    }
-
-    function inaccessibleAlert(alertMessage, workitem) {
-        if (workitem.status !== "inaccessible") {
-            assert.object(alertMessage);
-            var alertInfo = _.assign(
-                {
-                    nodeId: workitem.node,
-                    status: "inaccessible",
-                    pollerType: workitem.type,
-                    configure: workitem.config},
                 alertMessage
             );
             return events.publishNodeAlert(workitem.node, alertInfo);

--- a/lib/models/work-item.js
+++ b/lib/models/work-item.js
@@ -11,10 +11,11 @@ WorkItemModelFactory.$inject = [
     'Promise',
     'Assert',
     'Constants',
-    'Services.Configuration'
+    'Services.Configuration',
+    'Protocol.Events'
 ];
 
-function WorkItemModelFactory (Model, _, Promise, assert, Constants, configuration) {
+function WorkItemModelFactory (Model, _, Promise, assert, Constants, configuration, events) {
 
     function byPollers() {
         return {
@@ -81,6 +82,10 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                 type: 'boolean',
                 defaultsTo: false
             },
+            status:{
+                type: 'string',
+                defaultsTo: null
+            },
             toJSON: function() {
                 var obj = this.toObject();
                 obj.config = _.omit(obj.config, function(value, key) {
@@ -144,13 +149,19 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
             });
         },
 
-        setFailed: function setFailed(leaseToken, workItems) {
+        setFailed: function setFailed(leaseToken, alertMessage, workItems) {
             var self = this;
+            var newStatus = "inaccessible";
             if (!Array.isArray(workItems)) {
-                workItems = Array.prototype.slice.call(arguments, 1);
+                workItems = Array.prototype.slice.call(arguments, 2);
             }
             var now = new Date();
             return Promise.all(_.map(workItems, function (workItem) {
+                if (!alertMessage) {
+                    newStatus = workItem.status;
+                } else {
+                    inaccessibleAlert(alertMessage, workItem);
+                }
                 return self.update({
                     id: workItem.id,
                     leaseToken: leaseToken || workItem.leaseToken
@@ -159,20 +170,27 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                     failureCount: workItem.failureCount + 1,
                     lastFinished: now,
                     leaseToken: null,
-                    leaseExpires: null
+                    leaseExpires: null,
+                    status: newStatus
                 });
             })).then(function (workItems) {
                 return _.flattenDeep(workItems);
             });
         },
 
-        setSucceeded: function setSucceeded(leaseToken, workItems) {
+        setSucceeded: function setSucceeded(leaseToken, alertMessage, workItems) {
             var self = this;
+            var newStatus = "accessible";
             if (!Array.isArray(workItems)) {
-                workItems = Array.prototype.slice.call(arguments, 1);
+                workItems = Array.prototype.slice.call(arguments, 2);
             }
             var now = new Date();
             return Promise.all(_.map(workItems, function (workItem) {
+                if (!alertMessage) {
+                    newStatus = workItem.status;
+                } else {
+                    accessibleAlert(alertMessage, workItem);
+                }
                 return self.update({
                     id: workItem.id,
                     leaseToken: leaseToken || workItem.leaseToken
@@ -181,7 +199,8 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                     failureCount: 0,
                     lastFinished: now,
                     leaseToken: null,
-                    leaseExpires: null
+                    leaseExpires: null,
+                    status: newStatus 
                 });
             })).then(function (workItems) {
                 return _.flattenDeep(workItems);
@@ -246,4 +265,37 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
         sanitize(obj, /\./ig, '_');
         return next();
     }
+
+    function accessibleAlert(alertMessage, workitem) {
+        if (workitem.status !== "accessible") {
+            assert.object(alertMessage);
+            var alertInfo = _.assign(
+                {
+                    nodeId: workitem.node,
+                    status: "accessible",
+                    pollerType: workitem.type,
+                    configure: workitem.config
+                },
+                alertMessage
+            );
+            return events.publishNodeAlert(workitem.node, alertInfo);
+        }
+    }
+
+    function inaccessibleAlert(alertMessage, workitem) {
+        if (workitem.status !== "inaccessible") {
+            assert.object(alertMessage);
+            var alertInfo = _.assign(
+                {
+                    nodeId: workitem.node,
+                    status: "inaccessible",
+                    pollerType: workitem.type,
+                    configure: workitem.config},
+                alertMessage
+            );
+            return events.publishNodeAlert(workitem.node, alertInfo);
+        }
+    }
+
 }
+

--- a/spec/lib/models/work-item-spec.js
+++ b/spec/lib/models/work-item-spec.js
@@ -426,30 +426,30 @@ describe('Models.WorkItem', function () {
             this.sandbox.stub(events, "publishNodeAlert").resolves();
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
-                    return workitems.setFailed(null, {"any":"any"}, workItem);
+                    return workitems.setFailed(null, {"nodeType": "compute"}, workItem);
                 })
                 .then(function(failStatusItems) {
                     var failStatusItem = failStatusItems[0];
-                    expect(failStatusItem.status).to.equal('inaccessible');
+                    expect(failStatusItem.state).to.equal('inaccessible');
                     expect(events.publishNodeAlert)
                         .to.be.calledWith(failStatusItem.node, {
-                            any: "any",
+                            nodeType: "compute",
                             nodeId: failStatusItem.node,
-                            status: "inaccessible",
-                            pollerType: failStatusItem.type,
-                            configure: failStatusItem.config});
+                            state: "inaccessible"
+                            });
                 });
         });
 
         it('should not issue node inaccessible alert if status unchanged', function() {
-            this.sandbox.spy(events, "publishNodeAlert");
+            this.sandbox.stub(events, "publishNodeAlert").resolves();
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
-                    workItem.status = "inaccessible";
-                    return workitems.setFailed(null, {"any":"any"}, workItem);
+                    workItem.state = "accessible";
+                    return workitems.setFailed(null, {}, workItem);
                 })
-                .then(function() {
+                .then(function(newWorkitem) {
                     expect(events.publishNodeAlert).not.to.be.called;
+                    expect(newWorkitem[0].state).to.equal("inaccessible");
                 });
         });
 
@@ -457,12 +457,12 @@ describe('Models.WorkItem', function () {
             this.sandbox.spy(events, "publishNodeAlert");
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
-                    workItem.status = "accessible";
+                    workItem.state = "accessible";
                     return workitems.setFailed(null, null, workItem);
                 })
                 .then(function(newWorkItem) {
                     expect(events.publishNodeAlert).not.to.be.called;
-                    expect(newWorkItem[0].status).to.equal("accessible");
+                    expect(newWorkItem[0].state).to.equal("accessible");
                 });
         });
 
@@ -474,26 +474,26 @@ describe('Models.WorkItem', function () {
                 })
                 .then(function(successStatusItems) {
                     var successStatusItem = successStatusItems[0];
-                    expect(successStatusItem.status).to.equal('accessible');
+                    expect(successStatusItem.state).to.equal('accessible');
                     expect(events.publishNodeAlert)
                         .to.be.calledWith(successStatusItem.node, {
                             any: "any",
                             nodeId: successStatusItem.node,
-                            status: "accessible",
-                            pollerType: successStatusItem.type,
-                            configure: successStatusItem.config});
+                            state: "accessible",
+                            });
                 });
         });
 
         it('should not issue node accessible alert', function() {
-            this.sandbox.spy(events, "publishNodeAlert");
+            this.sandbox.stub(events, "publishNodeAlert").resolves();
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
-                    workItem.status = "accessible";
-                    return workitems.setSucceeded(null, {"any":"any"}, workItem);
+                    workItem.state = "inaccessible";
+                    return workitems.setSucceeded(null, {}, workItem);
                 })
-                .then(function() {
+                .then(function(newWorkitem) {
                     expect(events.publishNodeAlert).not.to.be.called;
+                    expect(newWorkitem[0].state).to.equal("accessible");
                 });
         });
 
@@ -501,12 +501,12 @@ describe('Models.WorkItem', function () {
             this.sandbox.spy(events, "publishNodeAlert");
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
-                    workItem.status = "inaccessible";
+                    workItem.state = "inaccessible";
                     return workitems.setSucceeded(null, null, workItem);
                 })
                 .then(function(newWorkItem) {
                     expect(events.publishNodeAlert).not.to.be.called;
-                    expect(newWorkItem[0].status).to.equal("inaccessible");
+                    expect(newWorkItem[0].state).to.equal("inaccessible");
                 });
         });
     });


### PR DESCRIPTION
This PR is to add alert capability in workitem .setFailed and .setSucceededwhen methods when pollers status changed and it is decided node alert should be issued.

A new argument is inserted in .setFailed and .setSucceded method and old tasks might be impacted and need update.

Code is Verified on D51, vPDU.

Related PR:
https://github.com/RackHD/on-tasks/pull/262