### PR TITLE
added store method for finding child graph

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -315,7 +315,8 @@ function constantsFactory (path) {
             Dae: 'dae',
             Pdu: 'pdu',
             Mgmt: 'mgmt',
-            Enclosure: 'enclosure'
+            Enclosure: 'enclosure',
+            Rack: 'rack'
         },
         Redfish: {
             EventTypes: {

--- a/lib/models/graph-object.js
+++ b/lib/models/graph-object.js
@@ -40,6 +40,14 @@ function GraphModelFactory (Model, Constants, configuration) {
             node: {
                 model: 'nodes'
             },
+            parentTaskId: {
+                type: 'string',
+                uuidv4: true
+            },
+            parentGraphId: {
+                type: 'string',
+                uuidv4: true
+            },
             active: function() {
                 var obj = this.toObject();
                 return Constants.Task.ActiveStates.indexOf(obj._status) > -1;

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -903,7 +903,7 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
             sort: {nextScheduled: 1},
             new: true
         };
-        
+
         var update = {
             $set: {
                 lastStarted: now,
@@ -948,7 +948,7 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
             where: {
                 $and: [
                     criteria || {},
-                    { 
+                    {
                         $or:  _(Constants.WorkItems.Pollers).map(function (pollerName) {
                             if( _.isString(pollerName)) {
                                 return { name: pollerName };
@@ -958,6 +958,24 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
                 ]
             }
         });
+    };
+
+    /**
+     * Finds the child graph of a runGraphJob by the job's task id/the child
+     * graph's parentTaskId
+     * @param {String} parentTaskId - The task id of a runGraphTask to match
+     * against a graph's context._parent.taskId field
+     * @returns {Promise} a promise for the graph with the given context._parent.taskId
+     * @memberOf store
+     */
+    exports.findChildGraph = function(parentTaskId) {
+        assert.uuid(parentTaskId, "Parent task ID should be a UUID");
+
+        var query = {
+            parentTaskId: parentTaskId
+        };
+
+        return waterline.graphobjects.findOneMongo(query);
     };
 
     return exports;

--- a/spec/lib/workflow/stores/mongo-spec.js
+++ b/spec/lib/workflow/stores/mongo-spec.js
@@ -13,6 +13,7 @@ describe('Task Graph mongo store interface', function () {
         return {
             publishRecord: sinon.stub(),
             findMongo: sinon.stub().resolves(),
+            findOneMongo: sinon.stub().resolves(),
             findAndModifyMongo: sinon.stub().resolves(),
             updateMongo: sinon.stub().resolves(),
             removeMongo: sinon.stub().resolves(),
@@ -108,8 +109,8 @@ describe('Task Graph mongo store interface', function () {
             var timeStamp = new Date();
 
             return mongo.setTaskStateInGraph(data).then(function(){
-                var modify = { $set: {} };                                      
-                modify.$set['tasks.' + data.taskId + '.state'] = 'succeeded';   
+                var modify = { $set: {} };
+                modify.$set['tasks.' + data.taskId + '.state'] = 'succeeded';
                 modify.$set.taskEndTime = timeStamp;
                 expect(waterline.graphobjects.findAndModifyMongo).to.have.been.calledOnce;
                 expect(waterline.graphobjects.findAndModifyMongo.args[0][0]).to.deep.equal(
@@ -134,8 +135,8 @@ describe('Task Graph mongo store interface', function () {
             var timeStamp = new Date();
 
             return mongo.setTaskStateInGraph(data).then(function(){
-                var modify = { $set: {} };                                      
-                modify.$set['tasks.' + data.taskId + '.state'] = 'succeeded';   
+                var modify = { $set: {} };
+                modify.$set['tasks.' + data.taskId + '.state'] = 'succeeded';
                 modify.$set.taskEndTime = timeStamp;
                 expect(waterline.graphobjects.findAndModifyMongo).to.have.been.calledOnce;
                 expect(waterline.graphobjects.findAndModifyMongo.args[0][0]).to.deep.equal(
@@ -165,7 +166,7 @@ describe('Task Graph mongo store interface', function () {
                 );
             });*/
 
-        });    
+        });
     });
 
     it('getTaskDefinition', function() {
@@ -707,6 +708,15 @@ describe('Task Graph mongo store interface', function () {
         .then(function() {
             expect(waterline.taskdependencies.createMongoIndexes).to.be
                 .calledWithExactly({taskId: 1, graphId: 1});
+        });
+    });
+
+    it('findChildGraph', function() {
+        var runGraphTaskId = uuid.v4();
+        return mongo.findChildGraph(runGraphTaskId)
+        .then(function() {
+            expect(waterline.graphobjects.findOneMongo).to.be
+                .calledWithExactly({"parentTaskId": runGraphTaskId});
         });
     });
 });


### PR DESCRIPTION
supports https://github.com/RackHD/on-tasks/pull/261 added store methods for finding a child graph by its parent task id. @RackHD/corecommitters @pscharla 