### PR TITLE
Add check graph succeeded method

### DIFF
--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -585,20 +585,22 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
     };
 
     /**
-     * Checks whether there are any pending, reachable, tasks corresponding to
+     * Checks whether there are any pending, reachable, or failed tasks corresponding to
      * the given graph ID.
      * @param {Object} data
      * @param {String} data.graphId - The uniqe ID of the graph to be checked
      * @retuns {Promise} a promise for an object with a boolean 'done' field
      * @memberOf store
      */
-    exports.checkGraphFinished = function(data) {
+    exports.checkGraphSucceeded = function(data) {
         assert.object(data, 'data');
         assert.uuid(data.graphId, 'data.graphId');
 
         var query = {
             graphId: data.graphId,
-            state: Constants.Task.States.Pending,
+            state: {
+                $ne: Constants.Task.States.Succeeded
+            },
             reachable: true
         };
 

--- a/spec/lib/workflow/stores/mongo-spec.js
+++ b/spec/lib/workflow/stores/mongo-spec.js
@@ -457,19 +457,19 @@ describe('Task Graph mongo store interface', function () {
         });
     });
 
-    it('checkGraphFinished not finished', function() {
+    it('checkGraphSucceeded not succeeded', function() {
         var data = {
             graphId: uuid.v4()
         };
         waterline.taskdependencies.findOne.resolves(data);
 
-        return mongo.checkGraphFinished(data)
+        return mongo.checkGraphSucceeded(data)
         .then(function(result) {
             expect(waterline.taskdependencies.findOne).to.have.been.calledOnce;
             expect(waterline.taskdependencies.findOne).to.have.been.calledWith(
                 {
                     graphId: data.graphId,
-                    state: Constants.Task.States.Pending,
+                    state: { $ne: Constants.Task.States.Succeeded },
                     reachable: true
                 }
             );
@@ -480,12 +480,12 @@ describe('Task Graph mongo store interface', function () {
         });
     });
 
-    it('checkGraphFinished finished', function() {
+    it('checkGraphSucceeded succeeded', function() {
         var data = {
             graphId: uuid.v4()
         };
         waterline.taskdependencies.findOne.resolves(null);
-        return expect(mongo.checkGraphFinished(data)).to.become({
+        return expect(mongo.checkGraphSucceeded(data)).to.become({
             graphId: data.graphId,
             done: true
         });


### PR DESCRIPTION
Adding basically a copy of the `checkGraphFinished` store method, but instead of querying for pending tasks, we query for pending AND failed tasks (i.e. != succeeded). This allows a higher level of the stack to prevent succeeding a graph when multiple terminal tasks finish at the same time, one with a failed state.

Fixes https://github.com/RackHD/RackHD/issues/295 along with https://github.com/RackHD/on-taskgraph/pull/137

@RackHD/corecommitters @stuart-stanley @VulpesArtificem 