### PR TITLE
Support node attribute change event

### DIFF
--- a/lib/models/node.js
+++ b/lib/models/node.js
@@ -12,11 +12,21 @@ NodeModelFactory.$inject = [
     'Promise',
     'Constants',
     'Services.Configuration',
+    'Protocol.Events',
     'Protocol.Waterline'
 ];
 
 var bson = require('bson');
-function NodeModelFactory (Model, waterline, _, Promise, Constants, configuration, waterlineProtocol) {
+function NodeModelFactory (
+    Model,
+    waterline,
+    _,
+    Promise,
+    Constants,
+    configuration,
+    eventsProtocol,
+    waterlineProtocol
+) {
     var dbType = configuration.get('databaseType', 'mongo');
 
     var attributes = {
@@ -194,6 +204,12 @@ function NodeModelFactory (Model, waterline, _, Promise, Constants, configuratio
                 return next();
             }
             return next();
-        }
+        },
+
+        getNodeById: function(nodeId) {
+            var self = this;
+            return self.findOne({id: nodeId}).populate('obms');
+        },
+
     });
 }

--- a/lib/models/obms.js
+++ b/lib/models/obms.js
@@ -6,6 +6,7 @@ module.exports = ObmsModelFactory;
 
 ObmsModelFactory.$provide = 'Models.Obms';
 ObmsModelFactory.$inject = [
+    'Logger',
     'Model',
     'Services.Waterline',
     '_',
@@ -14,10 +15,12 @@ ObmsModelFactory.$inject = [
     'Promise',
     'util',
     'Errors',
+    'Protocol.Events',
     'Assert'
 ];
 
 function ObmsModelFactory (
+    Logger,
     Model,
     waterline,
     _,
@@ -26,8 +29,10 @@ function ObmsModelFactory (
     Promise,
     util,
     Errors,
+    eventsProtocol,
     assert
 ) {
+    var logger = Logger.initialize(ObmsModelFactory);
     var secretsPattern = _.reduce(Constants.Logging.Redactions, function(pattern, regex) {
         return pattern ? util.format('%s|(?:%s)', pattern, regex.source) :
                          util.format('(?:%s)', regex.source);
@@ -128,7 +133,7 @@ function ObmsModelFactory (
                     return _revealSecrets(obm);
                 }
                 return obm;
-            })
+            });
         },
 
         // This function 'upserts' a new OBM into the obms collection.
@@ -146,6 +151,7 @@ function ObmsModelFactory (
         //    content at the time of the find query.
         upsertByNode: function(nodeId, obm) {
             var query;
+            var oldNode;
             var self = this;
 
             return Promise.try(function() {
@@ -157,6 +163,14 @@ function ObmsModelFactory (
                     "obms should be unique for a given node and service."
                 );
                 return _.first(obmSettings);
+            })
+            .tap(function() {
+                return waterline.nodes.getNodeById(nodeId)
+                .then(function(node) {
+                    if(node) {
+                        oldNode = node;
+                    }
+                });
             })
             .then(function(obmSetting) {
                 if(obmSetting) {
@@ -172,6 +186,18 @@ function ObmsModelFactory (
                 } else {
                     obm.node = nodeId;
                     return self.create(obm);
+                }
+            })
+            .tap(function() {
+                if (oldNode) {
+                    /* asynchronous, returned promise is ignored*/
+                    waterline.nodes.getNodeById(oldNode.id)
+                    .then(function (newNode) {
+                        return eventsProtocol.publishNodeAttrEvent(oldNode, newNode, 'obms');
+                    })
+                    .then(function (error) {
+                        logger.error('Error occur',error);
+                    });
                 }
             });
         },

--- a/lib/models/obms.js
+++ b/lib/models/obms.js
@@ -190,13 +190,13 @@ function ObmsModelFactory (
             })
             .tap(function() {
                 if (oldNode) {
-                    /* asynchronous, returned promise is ignored*/
+                    /* asynchronous, don't wait promise return for performance*/
                     waterline.nodes.getNodeById(oldNode.id)
                     .then(function (newNode) {
                         return eventsProtocol.publishNodeAttrEvent(oldNode, newNode, 'obms');
                     })
-                    .then(function (error) {
-                        logger.error('Error occur',error);
+                    .catch(function (error) {
+                        logger.error('Error occurs', error);
                     });
                 }
             });

--- a/lib/models/work-item.js
+++ b/lib/models/work-item.js
@@ -160,7 +160,7 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                 if (!alertMessage) {
                     newState = workItem.state;
                 } else if (! _.isEmpty(alertMessage)){
-                    accessibleAlert(alertMessage, workItem, newState);
+                    accessibleAlert(alertMessage, newState);
                 }
                 return self.update({
                     id: workItem.id,
@@ -189,7 +189,7 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
                 if (!alertMessage) {
                     newState = workItem.state;
                 } else if (!_.isEmpty(alertMessage)){
-                    accessibleAlert(alertMessage, workItem, newState);
+                    accessibleAlert(alertMessage, newState);
                 }
                 return self.update({
                     id: workItem.id,
@@ -266,17 +266,10 @@ function WorkItemModelFactory (Model, _, Promise, assert, Constants, configurati
         return next();
     }
 
-    function accessibleAlert(alertMessage, workitem, state) {
+    function accessibleAlert(alertMessage, state) {
         assert.string(state);
         assert.object(alertMessage);
-        var alertInfo = _.assign(
-            {
-                nodeId: workitem.node,
-                state: state
-            },
-            alertMessage
-        );
-        return events.publishNodeAlert(workitem.node, alertInfo);
+        return events.publishNodeEvent(alertMessage.node, state);
     }
 
 }

--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -11,7 +11,11 @@ eventsProtocolFactory.$inject = [
     'Assert'
 ];
 
-function eventsProtocolFactory (Constants, messenger, assert) {
+function eventsProtocolFactory (
+    Constants,
+    messenger,
+    assert
+) {
     function EventsProtocol () {
     }
 
@@ -227,6 +231,7 @@ function eventsProtocolFactory (Constants, messenger, assert) {
         );
     };
 
+    /* deprecated, remove this after migrated to publishNodeEvent() */
     EventsProtocol.prototype.publishNodeAlert = function (nodeId, data) {
         assert.string(nodeId);
         assert.object(data);
@@ -236,6 +241,55 @@ function eventsProtocolFactory (Constants, messenger, assert) {
             'node.alert' + '.' + nodeId,
             data || {}
         );
+    };
+
+    EventsProtocol.prototype.publishEvent = function (data) {
+        assert.object(data);
+        assert.string(data.type);
+
+        return messenger.publish(
+            Constants.Protocol.Exchanges.Events.Name,
+            'event' + '.' + data.type,
+            data || {}
+        );
+    };
+
+    /* TODO: If event payload need more info, please add 3th argument */
+    EventsProtocol.prototype.publishNodeEvent = function (node, action) {
+        var self = this;
+        assert.object(node);
+        assert.string(action);
+
+        var nodeEvent = {
+            type: 'node',
+            action: action,
+            nodeId: node.id,
+            nodeType: node.type
+        };
+
+        return self.publishEvent(nodeEvent);
+    };
+
+    EventsProtocol.prototype.publishNodeAttrEvent = function (oldNode, newNode, attr) {
+        var self = this;
+        var attrAction = self._getAttrAction(oldNode, newNode, attr);
+
+        if (attrAction) {
+            return self.publishNodeEvent(newNode, attr + '.' + attrAction);
+        }
+    };
+
+    EventsProtocol.prototype._getAttrAction = function (oldRecord, newRecord, attr) {
+        if (oldRecord && newRecord && oldRecord.id === newRecord.id) {
+            if (!_.isEmpty(oldRecord[attr]) && !_.isEmpty(newRecord[attr]) &&
+                    oldRecord[attr] !== newRecord[attr]) {
+                return 'updated';
+            } else if (!_.isEmpty(oldRecord[attr]) && _.isEmpty(newRecord[attr])) {
+                return 'unassigned';
+            } else if (_.isEmpty(oldRecord[attr]) && !_.isEmpty(newRecord[attr])) {
+                return 'assigned';
+            }
+        }
     };
 
     return new EventsProtocol();

--- a/spec/lib/models/work-item-spec.js
+++ b/spec/lib/models/work-item-spec.js
@@ -423,89 +423,83 @@ describe('Models.WorkItem', function () {
         });
 
         it('should issue node inaccessible alert', function() {
-            this.sandbox.stub(events, "publishNodeAlert").resolves();
+            var nodeObj  = { id: '123' }
+            this.sandbox.stub(events, "publishNodeEvent").resolves();
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
-                    return workitems.setFailed(null, {"nodeType": "compute"}, workItem);
+                    return workitems.setFailed(null, { node: nodeObj}, workItem);
                 })
                 .then(function(failStatusItems) {
                     var failStatusItem = failStatusItems[0];
                     expect(failStatusItem.state).to.equal('inaccessible');
-                    expect(events.publishNodeAlert)
-                        .to.be.calledWith(failStatusItem.node, {
-                            nodeType: "compute",
-                            nodeId: failStatusItem.node,
-                            state: "inaccessible"
-                            });
+                    expect(events.publishNodeEvent)
+                        .to.be.calledWith(nodeObj, "inaccessible");
                 });
         });
 
         it('should not issue node inaccessible alert if status unchanged', function() {
-            this.sandbox.stub(events, "publishNodeAlert").resolves();
+            this.sandbox.stub(events, "publishNodeEvent").resolves();
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
                     workItem.state = "accessible";
                     return workitems.setFailed(null, {}, workItem);
                 })
                 .then(function(newWorkitem) {
-                    expect(events.publishNodeAlert).not.to.be.called;
+                    expect(events.publishNodeEvent).not.to.be.called;
                     expect(newWorkitem[0].state).to.equal("inaccessible");
                 });
         });
 
         it('should not issue inaccessible alert if alert message is not delivered', function() {
-            this.sandbox.spy(events, "publishNodeAlert");
+            this.sandbox.spy(events, "publishNodeEvent");
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
                     workItem.state = "accessible";
                     return workitems.setFailed(null, null, workItem);
                 })
                 .then(function(newWorkItem) {
-                    expect(events.publishNodeAlert).not.to.be.called;
+                    expect(events.publishNodeEvent).not.to.be.called;
                     expect(newWorkItem[0].state).to.equal("accessible");
                 });
         });
 
         it('should issue node accessible alert', function() {
-            this.sandbox.stub(events, "publishNodeAlert").resolves();
+            var nodeObj = { id: '123' };
+            this.sandbox.stub(events, "publishNodeEvent").resolves();
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
-                    return workitems.setSucceeded(null, {"any":"any"}, workItem);
+                    return workitems.setSucceeded(null, { node: nodeObj}, workItem);
                 })
                 .then(function(successStatusItems) {
                     var successStatusItem = successStatusItems[0];
                     expect(successStatusItem.state).to.equal('accessible');
-                    expect(events.publishNodeAlert)
-                        .to.be.calledWith(successStatusItem.node, {
-                            any: "any",
-                            nodeId: successStatusItem.node,
-                            state: "accessible",
-                            });
+                    expect(events.publishNodeEvent)
+                        .to.be.calledWith(nodeObj, "accessible");
                 });
         });
 
         it('should not issue node accessible alert', function() {
-            this.sandbox.stub(events, "publishNodeAlert").resolves();
+            this.sandbox.stub(events, "publishNodeEvent").resolves();
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
                     workItem.state = "inaccessible";
                     return workitems.setSucceeded(null, {}, workItem);
                 })
                 .then(function(newWorkitem) {
-                    expect(events.publishNodeAlert).not.to.be.called;
+                    expect(events.publishNodeEvent).not.to.be.called;
                     expect(newWorkitem[0].state).to.equal("accessible");
                 });
         });
 
         it('should not issue accessible alert if alert message is not delivered', function() {
-            this.sandbox.spy(events, "publishNodeAlert");
+            this.sandbox.spy(events, "publishNodeEvent");
             return workitems.startNextScheduled(workerId, {}, 10 * 1000)
                 .then(function(workItem){
                     workItem.state = "inaccessible";
                     return workitems.setSucceeded(null, null, workItem);
                 })
                 .then(function(newWorkItem) {
-                    expect(events.publishNodeAlert).not.to.be.called;
+                    expect(events.publishNodeEvent).not.to.be.called;
                     expect(newWorkItem[0].state).to.equal("inaccessible");
                 });
         });

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -285,4 +285,57 @@ describe("Event protocol subscribers", function () {
             });
         });
     });
+
+    describe("publish node attribute event", function () {
+        it('should publish assigned event', function() {
+            var oldNode = {id: 'aaa', type: 'compute', sku: ''};
+            var newNode = {id: 'aaa', type: 'compute', sku: 'bbb'};
+
+            messenger.publish.resolves();
+
+            return events.publishNodeAttrEvent(oldNode, newNode, 'sku')
+            .then(function () {
+                expect(messenger.publish).to.have.been
+                .calledWith('on.events', 'event.node',
+                    { type: 'node',
+                      action: 'sku.assigned',
+                      nodeId : 'aaa',
+                      nodeType: 'compute' });
+            });
+        });
+
+        it('should attribute unassigned event', function() {
+            var oldNode = {id: 'aaa', type: 'compute', sku: 'bbb'};
+            var newNode = {id: 'aaa', type: 'compute', sku: ''};
+
+            messenger.publish.resolves();
+
+            return events.publishNodeAttrEvent(oldNode, newNode, 'sku')
+            .then(function () {
+                expect(messenger.publish).to.have.been
+                .calledWith('on.events', 'event.node',
+                    { type: 'node',
+                      action: 'sku.unassigned',
+                      nodeId : 'aaa',
+                      nodeType: 'compute' });
+            });
+        });
+
+        it('should attribute updated event', function() {
+            var oldNode = {id: 'aaa', type: 'compute', sku: 'bbb'};
+            var newNode = {id: 'aaa', type: 'compute', sku: 'ccc'};
+
+            messenger.publish.resolves();
+
+            return events.publishNodeAttrEvent(oldNode, newNode, 'sku')
+            .then(function () {
+                expect(messenger.publish).to.have.been
+                .calledWith('on.events', 'event.node',
+                    { type: 'node',
+                      action: 'sku.updated',
+                      nodeId : 'aaa',
+                      nodeType: 'compute' });
+            });
+        });
+    });
 });


### PR DESCRIPTION
docs: https://github.com/RackHD/docs/pull/296  'discovered' and 'removed' related PRs have been merged in previous PRs
there are some limitations to achieve functionality in waterline lifecycle functions, so implement in related places, this is a common function could be leveraged in other places

@RackHD/corecommitters @zyoung51 @WangWinson 