### PR TITLE
Add heartbeat event service

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -161,6 +161,14 @@ function constantsFactory (path) {
                         autoDelete: false
                     }
                 },
+                Heartbeat: {
+                    Name: 'on.heartbeat',
+                    Options: {
+                        type: 'topic',
+                        durable: true,
+                        autoDelete: false
+                    }
+                }
             }
         },
         Profiles: {
@@ -321,6 +329,9 @@ function constantsFactory (path) {
         HttpHeaders: {
             ApiProxyIp: 'X-RackHD-API-proxy-ip',
             ApiProxyPort: 'X-RackHD-API-proxy-port'
+        },
+        Heartbeat: {
+            defaultIntervalSec: 10
         }
     });
 

--- a/lib/services/heartbeat.js
+++ b/lib/services/heartbeat.js
@@ -1,0 +1,134 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+module.exports = heartbeatServiceFactory;
+
+heartbeatServiceFactory.$provide = 'Services.Heartbeat';
+heartbeatServiceFactory.$inject = [
+    'Promise',
+    'Services.Configuration',
+    'Assert',
+    'Constants',
+    'Rx',
+    'Services.Messenger',
+    'Result',
+    'Logger'
+];
+
+function heartbeatServiceFactory(
+    Promise,
+    configuration,
+    assert,
+    Constants,
+    Rx,
+    messenger,
+    Result,
+    Logger
+) {
+    var logger = Logger.initialize(heartbeatServiceFactory);
+
+    function HeartbeatService () {
+        this.intervalSec = parseInt(configuration.get(
+            'heartbeatIntervalSec', 
+            Constants.Heartbeat.defaultIntervalSec
+        ));
+        this.name = Constants.Name;
+        this.info = {
+            name: this.name,
+            title: process.title,
+            pid: process.pid,
+            uid: process.getuid(),
+            platform: process.platform,
+            release: process.release,
+            versions: process.versions,
+            memoryUsage: process.memoryUsage()
+        };
+    }
+    
+    HeartbeatService.prototype.requireDns = function() {
+        return Promise.promisifyAll(require('dns'));
+    };
+    
+    HeartbeatService.prototype.getCpuUsage = function() {
+        if(process.cpuUsage) {
+            return process.cpuUsage(this.startCpuUsage);
+        }
+        return 'NA'; // Added in: v6.1.0
+    };
+        
+    HeartbeatService.prototype.getFqdn = Promise.method(function() {
+        var self = this;
+        var dns = self.requireDns();
+        if(dns.lookupServiceAsync) {
+            return Promise.resolve(Constants.Host, {hints: dns.ADDRCONFIG})
+            .then(dns.lookupAsync)
+            .then(function(ip) {
+                return dns.lookupServiceAsync(ip[0], 0)
+                .then(function(fqdn, service) {
+                    return fqdn[0];
+                });
+            })
+            .catch(function() {
+                return Constants.Host;
+            });
+        }
+        return Constants.Host;
+    });
+    
+    HeartbeatService.prototype.isRunning = function() {
+        return this.running;
+    };
+    
+    HeartbeatService.prototype.sendHeartbeat = function() {
+        var self = this;
+        return messenger.publish(
+            Constants.Protocol.Exchanges.Heartbeat.Name,
+            self.routingKey, 
+            new Result({value: self.info})
+        )
+        .then(function() {
+            self.lastUpdate = self.info.currentTime;
+        });
+    };
+
+    HeartbeatService.prototype.start = function () {
+        var self = this;
+        if(this.intervalSec > 0) { // setting interval to 0 disables heartbeat
+            return self.getFqdn().then(function(fqdn) {
+                self.routingKey = fqdn + '.' + self.name;
+                self.running = true;
+                self.subscription = Rx.Observable.interval(self.intervalSec * 1000)
+                .takeWhile(self.isRunning.bind(self))
+                .subscribe(
+                    function() {
+                        self.info.currentTime = new Date();
+                        self.info.nextUpdate = new Date(
+                            self.info.currentTime.valueOf() + self.intervalSec * 1000
+                        );
+                        self.info.lastUpdate = self.lastUpdate
+                        self.info.memoryUsage = process.memoryUsage();
+                        self.info.cpuUsage = self.getCpuUsage();
+                        self.sendHeartbeat();
+                    },
+                    function(error) {
+                        if(error) {
+                            logger.error('Heartbeat service error', {error:error});
+                        }
+                    }
+                );
+                
+                return self.subscription;
+            });
+        }
+    };
+
+    HeartbeatService.prototype.stop = Promise.method(function () {
+        this.running = false;
+        if(this.subscription) {
+            this.subscription.dispose();
+        }
+    });
+
+    return new HeartbeatService();
+}

--- a/spec/lib/services/heartbeat-spec.js
+++ b/spec/lib/services/heartbeat-spec.js
@@ -1,0 +1,108 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+require('../../helper');
+
+describe('Heartbeat', function () {
+    var sandbox = sinon.sandbox.create();
+    var heartbeat;
+    var constants;
+    var subscription = {
+        dispose: sandbox.stub().resolves()
+    };
+    var rx = {
+        Observable: {
+            interval: sandbox.stub().returns({
+                takeWhile: sandbox.stub().returns({
+                    subscribe: sandbox.spy(function(f1,f2) {
+                        f1();
+                        f2({error:'error'});
+                        return {
+                            dispose: sandbox.stub().resolves(subscription)
+                        };
+                    })
+                })
+            })
+        }
+    };
+    var messenger = {
+        start: sandbox.stub().returns(
+            Promise.resolve()
+        ),
+        stop: sandbox.stub().returns(
+            Promise.resolve()
+        ),
+        publish: sandbox.stub().returns(
+            Promise.resolve()
+        )
+    };
+    var dns = {
+        lookupServiceAsync: sandbox.stub(),
+        lookupAsync: sandbox.stub()
+    };
+    
+    helper.before(function() {
+        return [ 
+            helper.di.simpleWrapper(messenger, 'Services.Messenger'),
+            helper.di.simpleWrapper(rx, 'Rx')
+        ]
+    });
+
+    before(function () {
+        heartbeat = helper.injector.get('Services.Heartbeat');
+        constants = helper.injector.get('Constants');
+        sandbox.stub(heartbeat, 'requireDns').returns(dns);
+    });
+    
+    beforeEach(function() {
+        sandbox.reset();
+    });
+
+    helper.after(function() {
+        sandbox.restore();
+    });
+
+    describe('heartbeatService', function() {
+        it('should start', function() {
+            return heartbeat.start()
+            .then(function() {
+                expect(rx.Observable.interval).to.be.calledOnce;
+                expect(heartbeat.subscription).to.be.resolved;
+                expect(heartbeat.running).to.be.true;
+            });
+        });
+        
+        it('should stop', function() {
+            return heartbeat.start().then(function() {
+                return heartbeat.stop().then(function() {
+                    expect(heartbeat.subscription.dispose).to.have.been.calledOnce;
+                    expect(heartbeat.running).to.be.false;
+                })
+            });
+        });
+        
+        it('should send heartbeat message', function() {
+            return heartbeat.sendHeartbeat()
+            .then(function() {
+                expect(messenger.publish).to.be.calledOnce;
+            });
+        });
+        
+        it('should resolve hostname', function() {
+            dns.lookupServiceAsync.resolves(undefined);
+            return heartbeat.getFqdn().then(function(hostname) {
+                expect(hostname).to.equal(constants.Host);
+            });
+        });
+        
+        it('should resolve FQDN', function() {
+            var testFqdn = constants.Host + '.example.com';
+            dns.lookupServiceAsync.resolves([testFqdn]);
+            dns.lookupAsync.resolves(['1.2.3.4', 4]);
+            return heartbeat.getFqdn().then(function(fqdn) {
+                expect(fqdn).to.equal(testFqdn);
+            });
+        });
+    });
+});
+


### PR DESCRIPTION
- Implements https://github.com/RackHD/RackHD/wiki/RackHD-Heartbeat-Event
- Periodically publish AMQP message with basic process and timestamp data for each running service.
- Configurable send interval, default to 10s. 
- Unit-tests

@RackHD/corecommitters @zyoung51 @tannoa2 @keedya @uppalk1 
