### PR TITLE
remove deprecated publishNodeAlert

### DIFF
--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -7,12 +7,14 @@ module.exports = eventsProtocolFactory;
 eventsProtocolFactory.$provide = 'Protocol.Events';
 eventsProtocolFactory.$inject = [
     'Constants',
+    '_',
     'Services.Messenger',
     'Assert'
 ];
 
 function eventsProtocolFactory (
     Constants,
+    _,
     messenger,
     assert
 ) {
@@ -228,18 +230,6 @@ function eventsProtocolFactory (
             Constants.Protocol.Exchanges.Events.Name,
             Constants.Events.Blocked,
             e
-        );
-    };
-
-    /* deprecated, remove this after migrated to publishNodeEvent() */
-    EventsProtocol.prototype.publishNodeAlert = function (nodeId, data) {
-        assert.string(nodeId);
-        assert.object(data);
-
-        return messenger.publish(
-            Constants.Protocol.Exchanges.Events.Name,
-            'node.alert' + '.' + nodeId,
-            data || {}
         );
     };
 

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -248,44 +248,6 @@ describe("Event protocol subscribers", function () {
         });
     });
 
-    describe("publish node alert", function () {
-        it("should fail because nodeId is not string", function () {
-            var nodeId = 2;
-            var alertData = {
-                nodeId: '47bd8fb80abc5a6b5e7b10df',
-                nodeType: 'compute',
-                state: 'discovered'
-            };
-
-            return expect(function(){ events.publishNodeAlert(nodeId, alertData); })
-            .to.throw(Error.AssertionError);
-        });
-
-        it("should fail because data is not object", function () {
-            var nodeId = '47bd8fb80abc5a6b5e7b10df';
-            var alertData = 'abc';
-
-            return expect(function(){ events.publishNodeAlert(nodeId, alertData); })
-            .to.throw(Error.AssertionError);
-        });
-
-        it("should publish pass", function () {
-            var nodeId = '47bd8fb80abc5a6b5e7b10df';
-            var alertData = {
-                nodeId: '47bd8fb80abc5a6b5e7b10df',
-                nodeType: 'compute',
-                state: 'discovered'
-            };
-
-            messenger.publish.resolves();
-
-            return events.publishNodeAlert(nodeId, alertData)
-            .then(function () {
-                expect(messenger.publish).to.have.been.calledOnce;
-            });
-        });
-    });
-
     describe("publish node attribute event", function () {
         it('should publish assigned event', function() {
             var oldNode = {id: 'aaa', type: 'compute', sku: ''};


### PR DESCRIPTION
funciton publishEvent() has been used and the migration is finished, so remove deprecated publishNodeAlert() , also fix the missing ‘_' in previous commit by mistake.

@RackHD/corecommitters @WangWinson @yyscamper 