### PR TITLE
Update JsonSchemaValidator to handle schema with namespace

### DIFF
--- a/lib/common/json-schema-validator.js
+++ b/lib/common/json-schema-validator.js
@@ -132,18 +132,20 @@ function jsonSchemaValidatorFactory(
      */
     JsonSchemaValidator.prototype.addSchemasByDir = function (schemaDir, metaSchemaName) {
         var self = this;
-
-        assert.string(schemaDir, 'schemaDir');
-        if (metaSchemaName) {
-            assert.string(metaSchemaName, 'metaSchemaName');
-        }
-
-        fs.readdirAsync(schemaDir)
+        return Promise.try(function () {
+            assert.string(schemaDir, 'schemaDir');
+            if (metaSchemaName) {
+                assert.string(metaSchemaName, 'metaSchemaName');
+            }
+        })
+        .then(function () {
+            return fs.readdirAsync(schemaDir);
+        })
         .filter(function (fileName) {
             return /\.json$/i.test(fileName);
         })
         .reduce(function (entries, fileName) {
-            return fs.readfileAsync(path.resolve(schemaDir, fileName))
+            return fs.readFileAsync(path.resolve(schemaDir, fileName))
             .then(function (fileData) {
                 var content = JSON.parse(fileData);
                 content.id = fileName;
@@ -156,7 +158,7 @@ function jsonSchemaValidatorFactory(
             if (metaSchemaName) {
                 var metaSchema = entries[metaSchemaName];
                 if (!metaSchema) {
-                    throw Errors.NotFoundError('Cannot find the meta schema "' + metaSchemaName +
+                    throw new Error('Cannot find the meta schema "' + metaSchemaName +
                         '" in directory "' + schemaDir + '"');
                 }
                 self.addMetaSchema(metaSchema);

--- a/lib/common/json-schema-validator.js
+++ b/lib/common/json-schema-validator.js
@@ -8,20 +8,25 @@ jsonSchemaValidatorFactory.$provide = 'JsonSchemaValidator';
 jsonSchemaValidatorFactory.$inject = [
     'Ajv',
     'Assert',
+    'Errors',
     '_'
 ];
 
 function jsonSchemaValidatorFactory(
     Ajv,
     assert,
+    Errors,
     _
 ) {
     var url = require('url');
+    var fs = require('fs');
+    var path = require('path');
+    var defaultNameSpace = 'http://rackhd.com/schemas/v1/'; // TODO: need it or not
 
     function JsonSchemaValidator(options) {
         this.options = options || {};
+        this.nameSpace = options.nameSpace || defaultNameSpace;
         this._ajv = new Ajv(this.options);
-        this.addSchema = this._ajv.addSchema;
         this.addMetaSchema = this._ajv.addMetaSchema;
     }
 
@@ -90,12 +95,92 @@ function jsonSchemaValidatorFactory(
     };
 
     /**
-     * Get compiled schema from the instance by `key` or `ref`.
-     * @param  {String} key `key` that was passed to `addSchema` or
-     *                  full schema reference (`schema.id` or resolved id).
+     * Add schema to the instance.
+     * @param {Object} schema
+     * @param {String} name Optional schema name when schema has an id
+     */
+    JsonSchemaValidator.prototype.addSchema = function (schema, name) {
+        assert.equal(_.isEmpty(name) && _.isEmpty(schema.id), false,
+                '`name` should not be empty, or `schema` should has an `id` property');
+
+        schema.id = url.resolve(this.nameSpace, name || schema.id);
+        return this._ajv.addSchema(schema);
+    };
+
+    /**
+     * Add array of schemas to the instance.
+     * @param {Array} schemas array of schema
+     */
+    JsonSchemaValidator.prototype.addSchemas = function (schemas) {
+        assert.arrayOfObject(schemas,
+                '`schemas` should be an array of JSON schema');
+        var self = this;
+        _.forEach(schemas, function (schema) {
+            self.addSchema(schema);
+        });
+    };
+
+    /**
+     * Add all schema in the folder to the instance.
+     * @param {String} schemaDir the directory where schema files in
+     * @param {String} metaSchemaName Optional the meta schema name
+     */
+    JsonSchemaValidator.prototype.addSchemasByDir = function (schemaDir, metaSchemaName) {
+        var self = this;
+
+        assert.string(schemaDir, 'schemaDir');
+        if (metaSchemaName) {
+            assert.string(metaSchemaName, 'metaSchemaName');
+        }
+
+        var fileNames = _.filter(fs.readdirSync(schemaDir), function (fileName) {
+            return path.extname(fileName).toLowerCase() === '.json';
+        });
+
+        var schemas = [];
+        var metaSchema;
+        _.forEach(fileNames, function(fileName) {
+            var fullName = path.resolve(schemaDir, fileName);
+            var data = fs.readFileSync(fullName);
+            var name = path.basename(fileName.toLowerCase(), '.json');
+            var content = JSON.parse(data.toString());
+            content.id = name;
+            if (metaSchemaName === fileName) {
+                metaSchema = content;
+            } else {
+                schemas.push(content);
+            }
+        });
+
+        //meta schema should be added first, so subsequent schemas can be validated againt it
+        if (metaSchemaName) {
+            if (!metaSchema) {
+                throw Errors.NotFoundError('Cannot find the meta schema "' + metaSchemaName +
+                    '" in directory "' + schemaDir + '"');
+            }
+            self.addMetaSchema(metaSchema);
+        }
+
+        self.addSchemas(schemas);
+    };
+
+    /**
+     * Get all schema names from the instance.
+     * @return {Array} schema names
+     */
+    JsonSchemaValidator.prototype.getAllSchemaNames = function() {
+        return _.filter(_.keys(this._ajv._schemas), function(schemaName) {
+            return !schemaName.startsWith('http://json-schema.org');
+        });
+    };
+
+    /**
+     * Get schema from the instance by name.
+     * @param  {String} name schema name or id
      * @return {Object} schema
      */
-    JsonSchemaValidator.prototype.getSchema = function (key) {
+    JsonSchemaValidator.prototype.getSchema = function (name) {
+        var key = url.resolve(this.nameSpace, name);
         var schemaCompiled = this._ajv.getSchema(key);
         if (schemaCompiled) {
             return schemaCompiled.schema;
@@ -103,12 +188,12 @@ function jsonSchemaValidatorFactory(
     };
 
     /**
-     * Get reference resolveed schema by `key`
-     * @param  {String} key `key` that was passed to `addSchema` or
-     *                  full schema reference (`schema.id` or resolved id).
+     * Get reference resolved schema by name.
+     * @param  {String} name schema name or id
      * @return {Object} schema with reference resolved
      */
-    JsonSchemaValidator.prototype.getSchemaResolved = function (key) {
+    JsonSchemaValidator.prototype.getSchemaResolved = function (name) {
+        var key = url.resolve(this.nameSpace, name);
         var schemaCompiled = this._ajv.getSchema(key);
         if (undefined === schemaCompiled) {
             return;
@@ -132,7 +217,7 @@ function jsonSchemaValidatorFactory(
         while (_.size(replaced) > 0) {
             var replacedLastLoop = replaced;
             replaced = {};
-            _.forOwn(replacedLastLoop, function (refValue, refId) {
+            _.forOwn(replacedLastLoop, function (refValue, refId) { //jshint ignore: line
                 replaceRefObj(refValue, resolvedValues, refId, replaced);
             });
         }
@@ -140,7 +225,7 @@ function jsonSchemaValidatorFactory(
         return schemaResolved;
 
         // resolve reference recursively
-        // it search the compiled schema data structure from ajv.getSchema, find out 
+        // it search the compiled schema data structure from ajv.getSchema, find out
         // and store referenced value to resolvedValues map
         function resolveRef(schemaObj, resolvedValues) {
             // the array store referenced value

--- a/lib/common/json-schema-validator.js
+++ b/lib/common/json-schema-validator.js
@@ -9,6 +9,9 @@ jsonSchemaValidatorFactory.$inject = [
     'Ajv',
     'Assert',
     'Errors',
+    'fs',
+    'path',
+    'Promise',
     '_'
 ];
 
@@ -16,16 +19,17 @@ function jsonSchemaValidatorFactory(
     Ajv,
     assert,
     Errors,
+    nodeFs,
+    path,
+    Promise,
     _
 ) {
     var url = require('url');
-    var fs = require('fs');
-    var path = require('path');
-    var defaultNameSpace = 'http://rackhd.com/schemas/v1/'; // TODO: need it or not
+    var fs = Promise.promisifyAll(nodeFs);
 
     function JsonSchemaValidator(options) {
         this.options = options || {};
-        this.nameSpace = options.nameSpace || defaultNameSpace;
+        this.nameSpace = options.nameSpace || '';
         this._ajv = new Ajv(this.options);
         this.addMetaSchema = this._ajv.addMetaSchema;
     }
@@ -97,7 +101,7 @@ function jsonSchemaValidatorFactory(
     /**
      * Add schema to the instance.
      * @param {Object} schema
-     * @param {String} name Optional schema name when schema has an id
+     * @param {String} [name] - Optional schema name when schema has an id
      */
     JsonSchemaValidator.prototype.addSchema = function (schema, name) {
         assert.equal(_.isEmpty(name) && _.isEmpty(schema.id), false,
@@ -109,7 +113,7 @@ function jsonSchemaValidatorFactory(
 
     /**
      * Add array of schemas to the instance.
-     * @param {Array} schemas array of schema
+     * @param {Array<Object>} schemas - array of schema
      */
     JsonSchemaValidator.prototype.addSchemas = function (schemas) {
         assert.arrayOfObject(schemas,
@@ -122,8 +126,9 @@ function jsonSchemaValidatorFactory(
 
     /**
      * Add all schema in the folder to the instance.
-     * @param {String} schemaDir the directory where schema files in
-     * @param {String} metaSchemaName Optional the meta schema name
+     * @param {String} schemaDir - the directory where schema files in
+     * @param {String} [metaSchemaName] - Optional the meta schema name
+     * @return {Promise}
      */
     JsonSchemaValidator.prototype.addSchemasByDir = function (schemaDir, metaSchemaName) {
         var self = this;
@@ -133,45 +138,53 @@ function jsonSchemaValidatorFactory(
             assert.string(metaSchemaName, 'metaSchemaName');
         }
 
-        var fileNames = _.filter(fs.readdirSync(schemaDir), function (fileName) {
-            return path.extname(fileName).toLowerCase() === '.json';
-        });
-
-        var schemas = [];
-        var metaSchema;
-        _.forEach(fileNames, function(fileName) {
-            var fullName = path.resolve(schemaDir, fileName);
-            var data = fs.readFileSync(fullName);
-            var name = path.basename(fileName.toLowerCase(), '.json');
-            var content = JSON.parse(data.toString());
-            content.id = name;
-            if (metaSchemaName === fileName) {
-                metaSchema = content;
-            } else {
-                schemas.push(content);
+        fs.readdirAsync(schemaDir)
+        .filter(function (fileName) {
+            return /\.json$/i.test(fileName);
+        })
+        .reduce(function (entries, fileName) {
+            return fs.readfileAsync(path.resolve(schemaDir, fileName))
+            .then(function (fileData) {
+                var content = JSON.parse(fileData);
+                content.id = fileName;
+                entries[fileName] = content;
+                return entries;
+            });
+        }, {})
+        .then(function (entries) {
+            //meta schema should be added first, so subsequent schemas can be validated againist it
+            if (metaSchemaName) {
+                var metaSchema = entries[metaSchemaName];
+                if (!metaSchema) {
+                    throw Errors.NotFoundError('Cannot find the meta schema "' + metaSchemaName +
+                        '" in directory "' + schemaDir + '"');
+                }
+                self.addMetaSchema(metaSchema);
+                delete entries[metaSchemaName];
             }
+            return entries;
+        })
+        .then(function (entries) {
+            self.addSchemas(_.values(entries));
         });
-
-        //meta schema should be added first, so subsequent schemas can be validated againt it
-        if (metaSchemaName) {
-            if (!metaSchema) {
-                throw Errors.NotFoundError('Cannot find the meta schema "' + metaSchemaName +
-                    '" in directory "' + schemaDir + '"');
-            }
-            self.addMetaSchema(metaSchema);
-        }
-
-        self.addSchemas(schemas);
     };
 
     /**
      * Get all schema names from the instance.
-     * @return {Array} schema names
+     * @param {Object} [option] - namespace will not be included by default,
+     *      set { includeNameSpace: true } when need to include namespace.
+     * @return {Array<String>} schemaNames
      */
-    JsonSchemaValidator.prototype.getAllSchemaNames = function() {
-        return _.filter(_.keys(this._ajv._schemas), function(schemaName) {
-            return !schemaName.startsWith('http://json-schema.org');
-        });
+    JsonSchemaValidator.prototype.getAllSchemaNames = function (option) {
+        var self = this;
+        return _(self._ajv._schemas).keys()
+        .filter(function (name) {
+            return name.startsWith(self.nameSpace);
+        })
+        .map(function (name) {
+            return option && option.includeNameSpace ? name : path.basename(name);
+        })
+        .value();
     };
 
     /**

--- a/lib/common/json-schema-validator.js
+++ b/lib/common/json-schema-validator.js
@@ -181,7 +181,8 @@ function jsonSchemaValidatorFactory(
         var self = this;
         return _(self._ajv._schemas).keys()
         .filter(function (name) {
-            return name.startsWith(self.nameSpace);
+            // filter out the default json-schema.org metaSchema
+            return  !/^http:\/\/json-schema.org/.test(name);
         })
         .map(function (name) {
             return option && option.includeNameSpace ? name : path.basename(name);

--- a/spec/lib/common/json-schema-validator-spec.js
+++ b/spec/lib/common/json-schema-validator-spec.js
@@ -5,6 +5,7 @@
 describe('JsonSchemaValidator', function () {
     var validator;
     var JsonSchemaValidator;
+    var ns = 'http://test.rackhd.org';
     var testSchema1 = {
         properties: {
             repo: {
@@ -42,7 +43,7 @@ describe('JsonSchemaValidator', function () {
     };
 
     var testRefSchema1Resolved = {
-        id: '/refschema/r1',
+        id: ns + '/refschema/r1',
         definitions: {
             url: {
                 type: 'string',
@@ -61,7 +62,7 @@ describe('JsonSchemaValidator', function () {
     };
 
     var testRefSchema2Resolved = {
-        id: '/refschema/r2',
+        id: ns + '/refschema/r2',
         properties: {
             repo: {
                 type: 'string',
@@ -126,7 +127,7 @@ describe('JsonSchemaValidator', function () {
     };
 
     var testRefSchema3Resolved = {
-        "id": "/refschema/r3",
+        "id": ns + "/refschema/r3",
         "definitions": {
             "UserName": {
                 "description": "The user account name",
@@ -214,7 +215,7 @@ describe('JsonSchemaValidator', function () {
     });
 
     beforeEach(function() {
-        validator = new JsonSchemaValidator({allErrors: true, verbose: true});
+        validator = new JsonSchemaValidator({allErrors: true, verbose: true, nameSpace: ns });
     });
 
     helper.after();
@@ -239,11 +240,18 @@ describe('JsonSchemaValidator', function () {
             expect(validator.addSchema(testRefSchema2)).to.be.empty;
         });
 
+        it('should throw assertion error when no name or id passed', function () {
+            expect(function () {
+                delete testSchema1.id;
+                validator.addSchema(testSchema1);
+            }).to.throw(/`name` should not be empty, or `schema` should has an `id` property/);
+        });
+
         it('should throw error when add duplicated key', function () {
             validator.addSchema(testSchema1, 'test1');
             expect(function () {
                 validator.addSchema(testSchema1, 'test1');
-            }).to.throw(/schema with key or id "test1" already exists/);
+            }).to.throw(/schema with key or id ".*\/test1" already exists/);
         });
     });
 

--- a/spec/lib/common/json-schema-validator-spec.js
+++ b/spec/lib/common/json-schema-validator-spec.js
@@ -28,7 +28,7 @@ describe('JsonSchemaValidator', function () {
                 $ref: '#/definitions/url'
             },
             index: {
-                type: 'number',
+                type: 'number'
             }
         }
     };
@@ -56,7 +56,7 @@ describe('JsonSchemaValidator', function () {
                 format: 'uri'
             },
             index: {
-                type: 'number',
+                type: 'number'
             }
         }
     };
@@ -208,6 +208,30 @@ describe('JsonSchemaValidator', function () {
         }
     };
 
+    var testRefSchema4 = {
+        $schema: 'testMetaSchema.json',
+        test: 'test metaSchema required property',
+        properties: {
+            repo: {
+                $ref: 'testRefSchema1.json#/definitions/url'
+            }
+        }
+    };
+
+    var testMetaSchema = {
+        allOf: [
+            {
+                $ref: 'http://json-schema.org/draft-04/schema'
+            }
+        ],
+        properties: {
+            test: {
+                type: 'string'
+            }
+        },
+        required: ['test']
+    };
+
     helper.before();
 
     before(function() {
@@ -252,6 +276,142 @@ describe('JsonSchemaValidator', function () {
             expect(function () {
                 validator.addSchema(testSchema1, 'test1');
             }).to.throw(/schema with key or id ".*\/test1" already exists/);
+        });
+    });
+
+    describe('addSchemas' , function () {
+        it('should add correct schema', function () {
+            expect(validator.addSchemas([testRefSchema1, testRefSchema2])).to.be.empty;
+        });
+
+        it('should throw assertion error incorrect schema param passed', function () {
+            expect(function () {
+                validator.addSchemas();
+            }).to.throw(/`schemas` should be an array of JSON schema/);
+            expect(function () {
+                validator.addSchemas({});
+            }).to.throw(/`schemas` should be an array of JSON schema/);
+            expect(function () {
+                validator.addSchemas([1,2,3]);
+            }).to.throw(/`schemas` should be an array of JSON schema/);
+        });
+    });
+
+    describe('addSchemasByDir' , function () {
+        var nodeFs;
+        before(function () {
+            nodeFs = helper.injector.get('fs');
+            sinon.stub(nodeFs, 'readdirAsync');
+            sinon.stub(nodeFs, 'readFileAsync');
+        });
+
+        beforeEach(function () {
+            nodeFs.readdirAsync.reset();
+            nodeFs.readFileAsync.reset();
+        });
+
+        it('should add correct schema by directory', function () {
+            nodeFs.readdirAsync.resolves([
+                'testSchema1.json',
+                'nosense',
+                'testRefSchema1.json',
+                'testRefSchema4.json',
+                'testMetaSchema.json'
+            ]);
+            nodeFs.readFileAsync.onCall(0).resolves(JSON.stringify(testSchema1));
+            nodeFs.readFileAsync.onCall(1).resolves(JSON.stringify(testRefSchema1));
+            nodeFs.readFileAsync.onCall(2).resolves(JSON.stringify(testRefSchema4));
+            nodeFs.readFileAsync.onCall(3).resolves(JSON.stringify(testMetaSchema));
+
+            return validator.addSchemasByDir('/testdir', 'testMetaSchema.json')
+            .then(function () {
+                expect(nodeFs.readdirAsync).to.be.calledOnce;
+                expect(nodeFs.readFileAsync).to.have.callCount(4);
+                expect(validator.getSchema('testSchema1.json')).to.have.property('id')
+                    .that.equals(ns + '/testSchema1.json');
+                expect(validator.getSchema('testRefSchema1.json')).to.have.property('id')
+                    .that.equals(ns + '/testRefSchema1.json');
+                expect(validator.getSchema('testRefSchema4.json')).to.have.property('id')
+                    .that.equals(ns + '/testRefSchema4.json');
+            });
+        });
+
+        it('should throw not found error when metaSchema not found', function (done) {
+            nodeFs.readdirAsync
+            .resolves(['testSchema1.json', 'testRefSchema1.json']);
+            nodeFs.readFileAsync.onCall(0).resolves(JSON.stringify(testSchema1));
+            nodeFs.readFileAsync.onCall(1).resolves(JSON.stringify(testRefSchema1));
+
+            return validator.addSchemasByDir('/testdir', 'noMetaSchema.json')
+            .then(function () {
+                done(new Error("Expect addSchemasByDir to fail"));
+            })
+            .catch(function (e) {
+                try {
+                    expect(e).to.have.property('message').that.equals(
+                        'Cannot find the meta schema "noMetaSchema.json" in directory "/testdir"');
+                    done();
+                }
+                catch (e) {
+                    done(e);
+                }
+            });
+        });
+
+        it('should throw assertion error when incorrect schemaDir passed', function (done) {
+            return validator.addSchemasByDir(123)
+            .then(function () {
+                done(new Error("Expect addSchemasByDir to fail"));
+            })
+            .catch(function (e) {
+                try {
+                    expect(e).to.have.property('message')
+                        .that.equals('schemaDir (string) is required');
+                    done();
+                }
+                catch (e) {
+                    done(e);
+                }
+            });
+        });
+
+        it('should throw assertion error when incorrect metaSchemaName passed', function (done) {
+            return validator.addSchemasByDir('testdir3', 456)
+            .then(function () {
+                done(new Error("Expect addSchemasByDir to fail"));
+            })
+            .catch(function (e) {
+                try {
+                    expect(e).to.have.property('message')
+                        .that.equals('metaSchemaName (string) is required');
+                    done();
+                }
+                catch (e) {
+                    done(e);
+                }
+            });
+        });
+
+        after(function () {
+            nodeFs.readdirAsync.restore();
+            nodeFs.readFileAsync.restore();
+        });
+    });
+
+    describe('getAllSchemaNames' , function () {
+        it('should list existing schema names', function () {
+            validator.addSchemas([testRefSchema1, testRefSchema3]);
+            expect(validator.getAllSchemaNames()).to.deep.equal(['r1', 'r3']);
+        });
+
+        it('should list existing schema names with namespace', function () {
+            validator.addSchemas([testRefSchema2, testRefSchema3]);
+            expect(validator.getAllSchemaNames({ includeNameSpace: true }))
+            .to.deep.equal([testRefSchema2Resolved.id, testRefSchema3Resolved.id]);
+        });
+
+        it('should not find any schema name when no schema added', function () {
+            expect(validator.getAllSchemaNames()).to.be.an('Array').with.length(0);
         });
     });
 


### PR DESCRIPTION
- Support customize namespace in `options.nameSpace` when instantiation.
- Add APIs `addSchema`, `addSchemas`, `addSchemasByDir` to add schemas via namespace.
- Add API `getAllSchemaNames` to return all schema names.
- Update API `getSchema` with namespace resolved.
- Add unit test for new added function.

@RackHD/corecommitters @iceiilin @cgx027 @pengz1 