### PR TITLE
add schemaRef in task-definition model

### DIFF
--- a/lib/models/task-definition.js
+++ b/lib/models/task-definition.js
@@ -38,6 +38,9 @@ function TaskModelFactory (Model, configuration) {
                 required: true,
                 json: true
             },
+            schemaRef: {
+                type: 'string'
+            },
             toJSON: function() {
                 // Remove waterline keys that we don't want in our graph objects
                 var obj = this.toObject();

--- a/spec/lib/models/task-definition-spec.js
+++ b/spec/lib/models/task-definition-spec.js
@@ -105,6 +105,20 @@ describe('Models.Task', function () {
                 expect(this.subject.json).to.equal(true);
             });
         });
+
+        describe('schemaRef', function () {
+            before(function () {
+                this.subject = this.attributes.schemaRef;
+            });
+
+            it('should be optional', function () {
+                expect(!this.subject.required).to.equal(true);
+            });
+
+            it('should be string', function () {
+                expect(this.subject.type).to.equal('string');
+            });
+        });
     });
 
     describe('object returned from toJSON()', function () {

--- a/spec/lib/models/task-definition-spec.js
+++ b/spec/lib/models/task-definition-spec.js
@@ -112,7 +112,7 @@ describe('Models.Task', function () {
             });
 
             it('should be optional', function () {
-                expect(!this.subject.required).to.equal(true);
+                expect(this.subject.optional).to.not.be.ok;
             });
 
             it('should be string', function () {


### PR DESCRIPTION
To support Task-Schema, a new key "schemaRef" is defined to store the reference of its task schema. Now it's set to be optional as not all existing tasks have associated schemas.

@RackHD/corecommitters @WangWinson @iceiilin 