### PR TITLE
Redact passwords

### DIFF
--- a/lib/common/model.js
+++ b/lib/common/model.js
@@ -14,7 +14,8 @@ ModelFactory.$inject = [
     'Errors',
     'Waterline',
     'Protocol.Waterline',
-    'Services.Waterline'
+    'Services.Waterline',
+    'Sanitizer'
 ];
 
 function ModelFactory (
@@ -26,7 +27,8 @@ function ModelFactory (
     Errors,
     Waterline,
     waterlineProtocol,
-    waterline
+    waterline,
+    sanitizer
 ) {
     var url = require('url');
 
@@ -195,6 +197,9 @@ function ModelFactory (
             }
             var update = args.shift();
 
+            // encrypt password fields
+            sanitizer.encrypt(update);
+
             // Don't validate if we're setting/unsetting individual properties
             if (update.$set || update.$setOnInsert) {
                 if (update.$setOnInsert) {
@@ -223,6 +228,7 @@ function ModelFactory (
             .then(function() {
                 return self.runNativeMongo('findAndModify', _arguments);
             });
+
         },
 
         updateMongo: function(filter, update, options) {

--- a/lib/common/sanitizer.js
+++ b/lib/common/sanitizer.js
@@ -1,0 +1,52 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+module.exports = SanitizerFactory;
+
+SanitizerFactory.$provide = 'Sanitizer';
+SanitizerFactory.$inject = [
+    'Services.Encryption',
+    'Constants',
+    'Util',
+    '_'
+];
+
+function SanitizerFactory (
+    encryption,
+    Constants,
+    util,
+    _
+) {
+
+    var secretsPattern = _.reduce(Constants.Logging.Redactions, function(pattern, regex) {
+        return pattern ? util.format('%s|(?:%s)', pattern, regex.source) :
+                         util.format('(?:%s)', regex.source);
+    }, '');
+    var secretsRegex = new RegExp(secretsPattern, 'i');
+
+    function sanitizer (obj) {
+        _.forOwn(obj, function(value, key) {
+            if (typeof(value) === 'object') {
+                sanitizer(value);
+            } else if ( key.match( secretsRegex )) {
+                obj[key] = encryption.encrypt(value);
+            }
+        });
+    }
+
+    function de_sanitizer (obj) {
+        _.forOwn(obj, function(value, key) {
+            if (typeof(value) === 'object') {
+                de_sanitizer(value);
+            } else if ( key.match( secretsRegex )) {
+                obj[key] = encryption.decrypt(value);
+            }
+        });
+    }
+
+    return {
+        encrypt: sanitizer,
+        decrypt: de_sanitizer
+    }
+}

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -9,10 +9,11 @@ mongoStoreFactory.$inject = [
     'Constants',
     'Errors',
     'Assert',
-    '_'
+    '_',
+    'Sanitizer'
 ];
 
-function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
+function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _, sanitizer) {
     var exports = {};
 
     exports.publishRecordByGraphId = function (graphId, event) {
@@ -202,7 +203,6 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
             new: true,
             upsert: true
         };
-
         return waterline.graphdefinitions.findAndModifyMongo(query, {}, definition, options);
     };
 
@@ -240,7 +240,6 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
             new: true,
             upsert: true
         };
-
         return waterline.taskdefinitions.findAndModifyMongo(query, {}, definition, options);
     };
 
@@ -307,7 +306,6 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
                 instanceId: 1
             }
         };
-
         return waterline.graphobjects.findAndModifyMongo(query, {}, graph, options);
     };
 
@@ -370,6 +368,7 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
 
         return waterline.graphobjects.findOne(query, options)
         .then(function(graph) {
+            sanitizer.decrypt(graph.tasks[data.taskId])
             return {
                 graphId: graph.instanceId,
                 context: graph.context,

--- a/spec/lib/common/sanitizer-spec.js
+++ b/spec/lib/common/sanitizer-spec.js
@@ -1,0 +1,48 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+describe('Sanitizer', function () {
+    var graphObj, sanitizer;
+    helper.before();
+
+    helper.after();
+
+    before (function () {
+        sanitizer = helper.injector.get('Sanitizer');
+
+        graphObj = {};
+        graphObj.id = 'testgraphid';
+        graphObj._status = 'pending';
+        graphObj.password = 'testPassword';
+        graphObj.definition = {
+            options: {
+                test_task: {
+                    password: "foo"
+                }
+            }
+        };
+    });
+
+    it ('it encrypts first level', function () {
+        sanitizer.encrypt(graphObj);
+        expect(graphObj.password).to.not.equal('testPassword');
+    });
+
+    it ('it encrypts nested levels', function () {
+        sanitizer.encrypt(graphObj);
+        expect(graphObj.definition.options.test_task.password).to.not.equal('foo');
+    });
+
+    it ('it decrypts as expected first level', function () {
+        sanitizer.encrypt(graphObj);
+        sanitizer.decrypt(graphObj);
+        expect(graphObj.password).to.equal('testPassword');
+    });
+
+    it ('it decrypts as expected nested levels', function () {
+        sanitizer.encrypt(graphObj);
+        sanitizer.decrypt(graphObj);
+        expect(graphObj.definition.options.test_task.password).to.equal('foo');
+    });
+});


### PR DESCRIPTION
resolves RackHD/RackHD#241

@RackHD/corecommitters

new PR at the request of @brianparry 's to place logic into graph-object model.

due to a number of issues hit attempting to make my earlier code testable, I refactored to use encryption so passwords are not saved in our database in plain text to begin with and will be naturally concealed from the user on a query.

unit tests are complete for this feature.  
