### PR TITLE
Add revealSecrets option to models.obms.upsertByNode

### DIFF
--- a/lib/models/obms.js
+++ b/lib/models/obms.js
@@ -149,7 +149,7 @@ function ObmsModelFactory (
         //    will cause the function fulfillment value to be inconsistent
         //    with the provided obm arguments but consistent with the document
         //    content at the time of the find query.
-        upsertByNode: function(nodeId, obm) {
+        upsertByNode: function(nodeId, obm, options) {
             var query;
             var oldNode;
             var self = this;
@@ -187,6 +187,12 @@ function ObmsModelFactory (
                     obm.node = nodeId;
                     return self.create(obm);
                 }
+            })
+            .then(function(obm) {
+                if (options && options.revealSecrets) {
+                    return _revealSecrets(obm);
+                }
+                return obm;
             })
             .tap(function() {
                 if (oldNode) {


### PR DESCRIPTION
Adding the option to return decrypted values when calling the obm model's upsertByNode method. Supports https://github.com/RackHD/on-tasks/pull/313

@RackHD/corecommitters @hohene @johren 