### PR TITLE
added findAllByNode to Obms

### DIFF
--- a/lib/models/obms.js
+++ b/lib/models/obms.js
@@ -208,6 +208,22 @@ function ObmsModelFactory (
             });
         },
 
+        findAllByNode: function(nodeId, reveal, query) {
+            var self = this;
+
+            query = query || {};
+            return Promise.try(function() {
+                    _.merge(query, {node: nodeId} );
+                    return self.find(query);
+                })
+                .then(function(obms) {
+                    if (obms && reveal) {
+                        return obms.map(_revealSecrets);
+                    }
+                    return obms;
+                });
+        },
+
         secret: function(attr) {
             return attr.match(secretsPattern);
         }

--- a/spec/lib/models/obms-spec.js
+++ b/spec/lib/models/obms-spec.js
@@ -215,6 +215,27 @@ describe('Models.Obms', function () {
                 expect(obm).to.be.undefined;
             });
         });
+
+        it('should find all nodes for nodeId', function() {
+            return obms.findAllByNode(nodeId, false)
+            .then(function(obms) {
+                expect(obms).to.have.length(testObms.length);
+                obms.forEach(function(obm) {
+                    expect(obm.node).to.equal(nodeId);
+                    expect(obm.toJSON().config).not.to.have.property('password');
+                });
+            });
+        });
+
+        it('should find all nodes for nodeId and reveal passwords', function() {
+            return obms.findAllByNode(nodeId, true, {service: 'ipmi-obm-service'})
+            .then(function(obms) {
+                expect(obms).to.have.length(1);
+                expect(obms[0].node).to.equal(nodeId);
+                expect(obms[0].service).to.equal('ipmi-obm-service');
+                expect(obms[0].config.password).to.equal(testObms[0].config.password);
+            });
+        });
     });
 
     describe('update', function() {


### PR DESCRIPTION
This is to support the GET route for nodes/id/obm
@brianparry @RackHD/corecommitters @BillyAbildgaard @srinia6 @dalebremner @keedya 