### PR TITLE
Optimize workflow mongo store publishRecordByGraphId to find/send les…

### DIFF
--- a/lib/common/model.js
+++ b/lib/common/model.js
@@ -182,8 +182,8 @@ function ModelFactory (
             });
         },
 
-        findOneMongo: function(query) {
-            return this.runNativeMongo('findOne', [query]);
+        findOneMongo: function(args) {
+            return this.runNativeMongo('findOne', args);
         },
 
         findAndModifyMongo: function() {
@@ -229,6 +229,27 @@ function ModelFactory (
                 return self.runNativeMongo('findAndModify', _arguments);
             });
 
+        },
+
+        needOneMongo: function () {
+            var identity = this.identity;
+            var args = Array.prototype.slice.call(arguments);
+
+            return this.findOneMongo(args)
+            .then(function (record) {
+                if (!record) {
+                    throw new Errors.NotFoundError(
+                        'Could not find %s with criteria %j.'.format(
+                            pluralize.singular(identity),
+                            args[0]
+                        ), {
+                            criteria: args[0],
+                            collection: identity
+                        });
+                }
+
+                return record;
+            });
         },
 
         updateMongo: function(filter, update, options) {

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -17,9 +17,11 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _, san
     var exports = {};
 
     exports.publishRecordByGraphId = function (graphId, event) {
-        return waterline.graphobjects.needOne({ instanceId: graphId })
-            .then(function (graph) {
-                exports.publishGraphRecord(graph, event, graphId);
+        return waterline.graphobjects.needOneMongo(
+                { instanceId: graphId },
+                { _status: 1, error: 1}
+            ).then(function (graphData) {
+                exports.publishGraphRecord(graphData, event, graphId);
             });
     };
 

--- a/spec/lib/common/model-spec.js
+++ b/spec/lib/common/model-spec.js
@@ -625,11 +625,11 @@ describe('Model', function () {
                         cb = (typeof params === 'function') ? params : cb;
                         cb();
                     }
-                }, 
+                },
                 done
             ]);
             this.sandbox.stub(Promise, 'promisifyAll', function() {
-                return { 
+                return {
                     connectAsync: connectAsync
                 };
             });
@@ -714,7 +714,7 @@ describe('Model', function () {
                 expect(waterline.testobjects.runNativeMongo).to.have.been.calledOnce;
                 expect(waterline.testobjects.runNativeMongo).to.have.been.calledWith(
                     'findOne',
-                    [query]
+                    query
                 );
             });
         });

--- a/spec/lib/workflow/stores/mongo-spec.js
+++ b/spec/lib/workflow/stores/mongo-spec.js
@@ -14,6 +14,7 @@ describe('Task Graph mongo store interface', function () {
             publishRecord: sinon.stub(),
             findMongo: sinon.stub().resolves(),
             findOneMongo: sinon.stub().resolves(),
+            needOneMongo: sinon.stub().resolves(),
             findAndModifyMongo: sinon.stub().resolves(),
             updateMongo: sinon.stub().resolves(),
             removeMongo: sinon.stub().resolves(),
@@ -717,6 +718,22 @@ describe('Task Graph mongo store interface', function () {
         .then(function() {
             expect(waterline.graphobjects.findOneMongo).to.be
                 .calledWithExactly({"parentTaskId": runGraphTaskId});
+        });
+    });
+
+    it('publishRecordByGraphId', function() {
+        var testObj = {};
+
+        waterline.graphobjects.needOneMongo.resolves(testObj);
+        waterline.graphobjects.publishRecord.resolves();
+
+        return mongo.publishRecordByGraphId('testid', 'testevent')
+        .then(function() {
+            expect(waterline.graphobjects.needOneMongo).to.have.been.calledWith(
+                { instanceId: 'testid' }
+            );
+            expect(waterline.graphobjects.publishRecord).to.have.been.calledWith(
+                'testevent', testObj, 'testid');
         });
     });
 });


### PR DESCRIPTION
…s data

If we have a bunch of tasks being updated at one time (at least dozens per second), then grabbing the entire graph object out of mongo and sending it over AMQP can add some unnecessary CPU load. This modifies the code to just grab the graph instanceId, status, and/or error fields instead. Will require some corresponding changes to the UI operations center to do a follow-up query on these events I believe (CC @rolandpoulter).

Doing some really, really rough benchmarking (a.k.a. eyeballing htop), running this function every 25ms had about 50% the CPU load as the old way (5-7% vs. 11-15%).

@RackHD/corecommitters @zyoung51 @jlongever @VulpesArtificem @pscharla 