### PR TITLE
Index graph object model instanceId attribute

### DIFF
--- a/lib/models/graph-object.js
+++ b/lib/models/graph-object.js
@@ -20,7 +20,8 @@ function GraphModelFactory (Model, Constants, configuration) {
                 type: 'string',
                 required: true,
                 unique: true,
-                uuidv4: true
+                uuidv4: true,
+                index: true
             },
             context: {
                 type: 'json',


### PR DESCRIPTION
Given this is our primary lookup field, we should probably index it.

@RackHD/corecommitters @VulpesArtificem