### PR TITLE
add scope as a field when finding file in renderable db

### DIFF
--- a/lib/common/db-renderable-content.js
+++ b/lib/common/db-renderable-content.js
@@ -191,7 +191,7 @@ function dbRenderableContentServiceFactory(
             i += 1;
         });
 
-        return waterline[self.collectionName].find({name: name})
+        return waterline[self.collectionName].find({name: name, scope: scope})
             .then(function(templates) {
                 if (!templates.length) { return undefined; }
 

--- a/lib/common/db-renderable-content.js
+++ b/lib/common/db-renderable-content.js
@@ -191,9 +191,14 @@ function dbRenderableContentServiceFactory(
             i += 1;
         });
 
-        return waterline[self.collectionName].find({name: name, scope: scope})
+        return waterline[self.collectionName].find({name: name})
             .then(function(templates) {
+
                 if (!templates.length) { return undefined; }
+
+                templates = templates.filter(function(obj){
+                    return scope.indexOf(obj.scope) > -1;
+                });
 
                 templates.sort(function(a,b) {
                     return scopeWeight[a.scope] - scopeWeight[b.scope];

--- a/spec/lib/common/db-renderable-content-spec.js
+++ b/spec/lib/common/db-renderable-content-spec.js
@@ -198,7 +198,7 @@ describe('db-renderable-content', function () {
                     expect(out[key]).to.equal(thing[key] || 'test contents');
                 });
                 expect(waterline.things.find)
-                    .to.have.been.calledWith({ name: 'test thing', scope: ["global"]});
+                    .to.have.been.calledWith({ name: 'test thing' });
             });
         });
 
@@ -231,7 +231,7 @@ describe('db-renderable-content', function () {
             .then(function(out) {
                 expect(out.contents).to.equal('b scope');
                 expect(waterline.things.find)
-                    .to.have.been.calledWith({ name: 'thing', scope: ["b", "a", "global"]});
+                    .to.have.been.calledWith({ name: 'thing' });
             });
         });
 
@@ -242,7 +242,7 @@ describe('db-renderable-content', function () {
             .then(function(out) {
                 expect(out).to.equal(undefined);
                 expect(waterline.things.find)
-                    .to.have.been.calledWith({ name: 'thing', scope: ["b"] });
+                    .to.have.been.calledWith({ name: 'thing' });
             });
         });
 
@@ -261,7 +261,27 @@ describe('db-renderable-content', function () {
             .then(function(out) {
                 expect(out.contents).to.equal('a scope');
                 expect(waterline.things.find)
-                    .to.have.been.calledWith({ name: 'thing', scope: ["b", "a", "global"] });
+                    .to.have.been.calledWith({ name: 'thing' });
+            });
+        });
+
+        it('should not get the thing that is not in the scope', function() {
+            var things = [
+                { name: 'thing', path: 'b scope', scope: 'b'},
+                { name: 'thing', path: 'global', scope: 'global'},
+                { name: 'thing', path: 'a scope', scope: 'a'}
+            ];
+            var scope = ['a', 'global'];
+            waterline.things.find.resolves(things);
+            _.forEach(things, function(thing) {
+                loader.prototype.get.withArgs(thing.path).resolves(thing.path);
+                thing.hash = crypto.createHash('md5').update(thing.path).digest('base64');
+            });
+            return this.subject.get('thing', scope)
+            .then(function(out) {
+                expect(out.contents).to.equal('a scope');
+                expect(waterline.things.find)
+                    .to.have.been.calledWith({ name: 'thing' });
             });
         });
 

--- a/spec/lib/common/db-renderable-content-spec.js
+++ b/spec/lib/common/db-renderable-content-spec.js
@@ -198,7 +198,7 @@ describe('db-renderable-content', function () {
                     expect(out[key]).to.equal(thing[key] || 'test contents');
                 });
                 expect(waterline.things.find)
-                    .to.have.been.calledWith({ name: 'test thing'});
+                    .to.have.been.calledWith({ name: 'test thing', scope: ["global"]});
             });
         });
 
@@ -231,7 +231,7 @@ describe('db-renderable-content', function () {
             .then(function(out) {
                 expect(out.contents).to.equal('b scope');
                 expect(waterline.things.find)
-                    .to.have.been.calledWith({ name: 'thing'});
+                    .to.have.been.calledWith({ name: 'thing', scope: ["b", "a", "global"]});
             });
         });
 
@@ -242,7 +242,7 @@ describe('db-renderable-content', function () {
             .then(function(out) {
                 expect(out).to.equal(undefined);
                 expect(waterline.things.find)
-                    .to.have.been.calledWith({ name: 'thing' });
+                    .to.have.been.calledWith({ name: 'thing', scope: ["b"] });
             });
         });
 
@@ -261,7 +261,7 @@ describe('db-renderable-content', function () {
             .then(function(out) {
                 expect(out.contents).to.equal('a scope');
                 expect(waterline.things.find)
-                    .to.have.been.calledWith({ name: 'thing' });
+                    .to.have.been.calledWith({ name: 'thing', scope: ["b", "a", "global"] });
             });
         });
 


### PR DESCRIPTION
Currently, when finding a template, all files with the same name will be returned, despite of the desired scope. If the there are 3 scopes (say ["a", "b", "global"]) in database, but user only want to find two of them (["a", "global"]), it is possible that the final file would be for scope "b" after sorting by priority.

Add scope filed when querying database.

@zyoung51 