### PR TITLE
Updated node events to include additional data when published

### DIFF
--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -145,12 +145,10 @@ function eventsProtocolFactory (
     };
 
     EventsProtocol.prototype.publishNodeNotification = function (nodeId, data) {
-        var _data = data || '';
-
         return messenger.publish(
             Constants.Protocol.Exchanges.Events.Name,
             'notification' + '.' + nodeId,
-            data
+            data || ''
         );
     };
 
@@ -165,12 +163,10 @@ function eventsProtocolFactory (
     };
 
     EventsProtocol.prototype.publishBroadcastNotification = function (data) {
-        var _data = data || '';
-
         return messenger.publish(
             Constants.Protocol.Exchanges.Events.Name,
             'notification',
-            data
+            data || ''
         );
     };
     EventsProtocol.prototype.subscribeBroadcastNotification = function (callback) {
@@ -286,12 +282,11 @@ function eventsProtocolFactory (
         return messenger.publish(
             Constants.Protocol.Exchanges.Events.Name,
             'event' + '.' + data.type,
-            data || {}
+            data
         );
     };
 
-    /* TODO: If event payload need more info, please add 3th argument */
-    EventsProtocol.prototype.publishNodeEvent = function (node, action) {
+    EventsProtocol.prototype.publishNodeEvent = function (node, action, data) {
         var self = this;
         assert.object(node);
         assert.string(action);
@@ -302,6 +297,10 @@ function eventsProtocolFactory (
             nodeId: node.id,
             nodeType: node.type
         };
+
+        if(data){
+            nodeEvent.data = data;
+        }
 
         return self.publishEvent(nodeEvent);
     };

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -172,31 +172,36 @@ describe("Event protocol subscribers", function () {
                 expect(_data).to.deep.equal(data);
             }).then(function (subscription) {
                 expect(subscription).to.be.ok;
-                return events.publishNodeNotification(
+                events.publishNodeNotification(
                     nodeId,
+                    data
+                );
+                expect(messenger.publish).to.have.been.calledWith(
+                    'on.events',
+                    'notification.' + nodeId,
                     data
                 );
             });
         });
 
         it("should publish and subscribe to NodeNotification messages without data", function(){
-            var nodeId = '57a86b5c36ec578876878294',
-                data = {
-                    nodeId: nodeId,
-                    data: 'test data'
-                };
+            var nodeId = '57a86b5c36ec578876878294';
             messenger.subscribe = sinon.spy(function(a,b,callback) {
-                callback(data,testMessage);
+                callback(testMessage);
                 return Promise.resolve(testSubscription);
             });
             messenger.publish.resolves();
 
-            return events.subscribeNodeNotification(nodeId, function (_data) {
-                expect(_data).to.deep.equal(data);
+            return events.subscribeNodeNotification(nodeId, function () {
             }).then(function (subscription) {
                 expect(subscription).to.be.ok;
-                return events.publishNodeNotification(
+                events.publishNodeNotification(
                     nodeId
+                );
+                expect(messenger.publish).to.have.been.calledWith(
+                    'on.events',
+                    'notification.' + nodeId,
+                    ''
                 );
             });
         });
@@ -215,27 +220,33 @@ describe("Event protocol subscribers", function () {
                 expect(_data).to.deep.equal(data);
             }).then(function (subscription) {
                 expect(subscription).to.be.ok;
-                return events.publishBroadcastNotification(
+                events.publishBroadcastNotification(
+                    data
+                );
+                expect(messenger.publish).to.have.been.calledWith(
+                    'on.events',
+                    'notification',
                     data
                 );
             });
         });
 
         it("should publish and subscribe to BroadcastNotification messages without data", function(){
-            var data = {
-                    data: 'test data'
-                };
             messenger.subscribe = sinon.spy(function(a,b,callback) {
-                callback(data,testMessage);
+                callback(testMessage);
                 return Promise.resolve(testSubscription);
             });
             messenger.publish.resolves();
 
-            return events.subscribeBroadcastNotification(function (_data) {
-                expect(_data).to.deep.equal(data);
+            return events.subscribeBroadcastNotification(function () {
             }).then(function (subscription) {
                 expect(subscription).to.be.ok;
-                return events.publishBroadcastNotification();
+                events.publishBroadcastNotification();
+                expect(messenger.publish).to.have.been.calledWith(
+                    'on.events',
+                    'notification',
+                    ''
+                );
             });
         });
     });


### PR DESCRIPTION
Related changes in `on-tasks`
https://github.com/RackHD/on-tasks/pull/350

Publish node event message with additional data, if provided.