### PR TITLE
support task-schema refactor

### DIFF
--- a/lib/common/json-schema-validator.js
+++ b/lib/common/json-schema-validator.js
@@ -31,6 +31,7 @@ function jsonSchemaValidatorFactory(
         this.nameSpace = options.nameSpace || '';
         this._ajv = new Ajv(this.options);
         this.addMetaSchema = this._ajv.addMetaSchema;
+        this.removeSchema = this._ajv.removeSchema;
     }
 
     /**

--- a/lib/models/task-definition.js
+++ b/lib/models/task-definition.js
@@ -38,8 +38,8 @@ function TaskModelFactory (Model, configuration) {
                 required: true,
                 json: true
             },
-            schemaRef: {
-                type: 'string'
+            optionsSchema: {
+                type: 'json'
             },
             toJSON: function() {
                 // Remove waterline keys that we don't want in our graph objects

--- a/spec/lib/models/task-definition-spec.js
+++ b/spec/lib/models/task-definition-spec.js
@@ -106,17 +106,17 @@ describe('Models.Task', function () {
             });
         });
 
-        describe('schemaRef', function () {
+        describe('optionsSchema', function () {
             before(function () {
-                this.subject = this.attributes.schemaRef;
+                this.subject = this.attributes.optionsSchema;
             });
 
             it('should be optional', function () {
                 expect(this.subject.optional).to.not.be.ok;
             });
 
-            it('should be string', function () {
-                expect(this.subject.type).to.equal('string');
+            it('should be json', function () {
+                expect(this.subject.type).to.equal('json');
             });
         });
     });


### PR DESCRIPTION
Change including:
(1) Task-Definition: replace schemaRef with optionsSchema, optionsSchema can be either string or object, so set its type to `json`. 
(2) add removeSchema API for JSON schema validator;

@RackHD/corecommitters @iceiilin @pengz1 @cgx027 @lanchongyizu @amymullins 
