### PR TITLE
Fix ssh validation failure when only using default rootPassword

### DIFF
--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -372,6 +372,7 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _, san
         return waterline.graphobjects.findOne(query, options)
         .then(function(graph) {
             sanitizer.decrypt(graph.tasks[data.taskId]);
+            sanitizer.decrypt(graph.context);
             return {
                 graphId: graph.instanceId,
                 context: graph.context,


### PR DESCRIPTION
When only using default `rootPassword`, it fails ssh validation.
 It is caused by the encripted password not being decripted in context when pulling the task data.

The payload used is
```
{
    "options": {
        "defaults": {
            "version": "6.0",
            "repo": "http://10.62.59.209/static/mirrors/esxi/6.0",
            "rootPassword": "Password0",
            "hostname": "rackhd",
            "dnsServers": ["172.12.88.91"],
            "ntpServers": ["0.vmware.pool.ntp.org", "1.vmware.pool.ntp.org"],
            "installDisk": 0
        }
    }
}
```


@RackHD/corecommitters @panpan0000 @iceiilin 