### PR TITLE
Pin apache-md5 to version 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "always-tail": "^0.1.1",
     "amqp": "0.2.3",
     "anchor": "^0.10.2",
+    "apache-md5": "1.0.6",
     "apache-crypt": "1.0.9",
     "assert-plus": "^1.0.0",
     "bluebird": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "always-tail": "^0.1.1",
     "amqp": "0.2.3",
     "anchor": "^0.10.2",
-    "apache-md5": "1.0.6",
+    "apache-md5": "1.0.5",
     "apache-crypt": "1.0.9",
     "assert-plus": "^1.0.0",
     "bluebird": "^2.8.0",


### PR DESCRIPTION
We are running the OnRack 1.2 branch on Ubuntu 14.04 which currently (in 14.04.5) has node 0.10.25.

on-core has a dependency on apache-crypt 1.0.9 which itself has an unpinned dependency on apache-md5.  In the 1.2.4 timeframe, the apache-md5 version installed was 1.0.6.  Sometime after
1.2.4 was released, a new version (1.1.1) of apache-md5 became available and is, therefore, now installed.   This version has code that requires node >=4.   

Therefore, with the latest 1.2 builds of on-http, on-taskgraph, on-tftp, on-syslog, and on-dhcp-proxy, these services fail to start up on Ubuntu 14.04 running node 0.10.25.

The solution we have implemented for 1.2.5 is to add a dependency of apache-md5 1.0.6 to on-core so that apache-crypt does not pull in version 1.1.1.   

Tested this with a debian build of on-http installed on one of our development stacks.

This change is not required in master since we don't have a specific tie to node 0.10.25 outside of the 1.2.0 branch.