### PR TITLE
fix mongo indexes creation for all models

### DIFF
--- a/lib/common/model.js
+++ b/lib/common/model.js
@@ -131,6 +131,50 @@ function ModelFactory (
             });
         },
 
+        /**
+         * Create indexes for different database
+         *
+         * the waterline has bug for index creation and it also doesn't support compound index,
+         * this function is to manually create indexes regardless what waterline will do. This
+         * function support both single-field and compound index
+         *
+         * @return {Promise} Resolved if create indexes successfully.
+         */
+        createIndexes: function () {
+            var self = this;
+            var indexes = self.$indexes || [];
+
+            return Promise.try (function() {
+                assert.arrayOfObject(indexes, '$indexes should be an array of object');
+
+                //validate and assign default arguments before creating indexes
+                //if necessary, convert the indexes format to fit for different database
+                _.forEach(indexes, function(indexItem) {
+                    assert.object(indexItem.keys, 'Database index keys should be object');
+                    if (indexItem.options) {
+                        assert.object(indexItem.options, 'Database index options should be object');
+                    }
+                    else {
+                        indexItem.options = {};
+                    }
+                });
+
+                return indexes;
+            }).then(function(indexes) {
+                if (_.isEmpty(indexes)) {
+                    return;
+                }
+                switch(self.connection.toString()) {
+                    case 'mongo':
+                        return Promise.map(indexes, function(indexItem) {
+                            return self.createMongoIndexes([indexItem.keys, indexItem.options]);
+                        });
+                    default:
+                        break;
+                }
+            });
+        },
+
         runQuery: function( querystr, params ) {
             return Promise.fromNode(this.query.bind(this, querystr, params));
         },

--- a/lib/models/catalog.js
+++ b/lib/models/catalog.js
@@ -12,7 +12,12 @@ CatalogModelFactory.$inject = [
     'uuid'
 ];
 
-function CatalogModelFactory (Model, _, configuration, uuid) {
+function CatalogModelFactory (
+    Model,
+    _,
+    configuration,
+    uuid
+) {
     return Model.extend({
         connection: configuration.get('databaseType', 'mongo'),
         identity: 'catalogs',
@@ -27,8 +32,7 @@ function CatalogModelFactory (Model, _, configuration, uuid) {
             },
             node: {
                 model: 'nodes',
-                required: true,
-                index: true
+                required: true
             },
             source: {
                 type: 'string',
@@ -40,10 +44,24 @@ function CatalogModelFactory (Model, _, configuration, uuid) {
                 json: true
             }
         },
+
         beforeCreate: function(values, cb) {
             values.data = updateKeys(values.data, _);
             cb();
         },
+
+        $indexes: [
+            {
+                keys: { node: 1 }
+            },
+            {
+                keys: { source: 1 }
+            },
+            {
+                keys: { node: 1, source: 1 },
+                options: { unique: false } //not unique index since we allow old catalogs exist
+            }
+        ],
 
         /**
          * Retrieves the most recent catalog of the source identified for the given node

--- a/lib/models/environment.js
+++ b/lib/models/environment.js
@@ -18,13 +18,20 @@ function EnvModelFactory (Model, configuration) {
             identifier: {
                 type: 'string',
                 required: true,
-                primaryKey: true
+                primaryKey: true,
+                unique: true
             },
             data: {
                 type: 'json',
                 required: true,
                 json: true
             }
-        }
+        },
+        $indexes: [
+            {
+                keys: { identifier: 1 },
+                options: { unique: true }
+            }
+        ]
     });
 }

--- a/lib/models/file.js
+++ b/lib/models/file.js
@@ -55,6 +55,12 @@ function FileModelFactory (Model, configuration) {
                 delete obj.updatedAt;
                 return obj;
             }
-        }
+        },
+        $indexes: [
+            {
+                keys: { basename: 1 },
+                options: { unique: true }
+            }
+        ]
     });
 }

--- a/lib/models/graph-definition.js
+++ b/lib/models/graph-definition.js
@@ -21,8 +21,7 @@ function GraphModelFactory (Model, configuration) {
             },
             injectableName: {
                 type: 'string',
-                required: true,
-                unique: true
+                required: true
             },
             tasks: {
                 type: 'array',
@@ -37,6 +36,12 @@ function GraphModelFactory (Model, configuration) {
                 delete obj.id;
                 return obj;
             }
-        }
+        },
+        $indexes: [
+            {
+                keys: { injectableName: 1 },
+                options: { unique: true }
+            }
+        ]
     });
 }

--- a/lib/models/graph-object.js
+++ b/lib/models/graph-object.js
@@ -11,7 +11,11 @@ GraphModelFactory.$inject = [
     'Services.Configuration'
 ];
 
-function GraphModelFactory (Model, Constants, configuration) {
+function GraphModelFactory (
+    Model,
+    Constants,
+    configuration
+) {
     return Model.extend({
         connection: configuration.get('taskgraph-store', 'mongo'),
         identity: 'graphobjects',
@@ -52,6 +56,12 @@ function GraphModelFactory (Model, Constants, configuration) {
                 var obj = this.toObject();
                 return Constants.Task.ActiveStates.indexOf(obj._status) > -1;
             }
-        }
+        },
+        $indexes: [
+            {
+                keys: { instanceId: 1 },
+                options: { unique: true }
+            }
+        ]
     });
 }

--- a/lib/models/local-user.js
+++ b/lib/models/local-user.js
@@ -54,6 +54,12 @@ function LocalUserModelFactory (Model, configuration) {
                 return verify.toString('binary') === hash;
             }
         },
+        $indexes: [
+            {
+                keys: { username: 1 },
+                options: { unique: true }
+            }
+        ],
         beforeCreate: serialize,
         beforeUpdate: serialize
     });
@@ -64,7 +70,7 @@ function LocalUserModelFactory (Model, configuration) {
                 return next(err);
             }
 
-            crypto.pbkdf2(obj.password, salt, hashConfig.iterations, hashConfig.hashBytes, function(err, hash) {
+            crypto.pbkdf2(obj.password, salt, hashConfig.iterations, hashConfig.hashBytes, function(err, hash) { //jshint ignore: line
                 if (err) {
                     return next(err);
                 }

--- a/lib/models/lookup.js
+++ b/lib/models/lookup.js
@@ -17,19 +17,27 @@ LookupModelFactory.$inject = [
     '_'
 ];
 
-function LookupModelFactory (waterline, Model, assert, Errors, Promise, Constants, configuration, validator, _) {
+function LookupModelFactory (
+    waterline,
+    Model,
+    assert,
+    Errors,
+    Promise,
+    Constants,
+    configuration,
+    validator,
+    _
+) {
     var dbType = configuration.get('databaseType', 'mongo');
     return Model.extend({
         connection: dbType,
         identity: 'lookups',
         attributes: {
             node: {
-                model: 'nodes',
-                index: true
+                model: 'nodes'
             },
             ipAddress: {
                 type: 'string',
-                unique: true,
                 regex: Constants.Regex.IpAddress
             },
             macAddress: {
@@ -43,6 +51,24 @@ function LookupModelFactory (waterline, Model, assert, Errors, Promise, Constant
             }
         },
 
+        $indexes: [
+            {
+                keys: { node: 1}
+            },
+            {
+                keys: { ipAddress: 1},
+                options: { unique: false }
+            },
+            {
+                keys: { macAddress: 1},
+                options: { unique: true }
+            },
+            {
+                keys: { macAddress: 1, ipAddress: 1 },
+                options: { unique: true }
+            }
+        ],
+
         findByTerm: function (term) {
             var query = {}; //empty query will find all entries
             if(validator.isIP(term)) {
@@ -50,7 +76,7 @@ function LookupModelFactory (waterline, Model, assert, Errors, Promise, Constant
             } else if( validator.isMongoId(term)) {
                 query.node = term;
             } else if(term) {
-                query.macAddress = _.map(_.isArray(term) ? term : [ term ], 
+                query.macAddress = _.map(_.isArray(term) ? term : [ term ],
                     function(term) {
                         return term.toLowerCase();
                     });
@@ -81,10 +107,19 @@ function LookupModelFactory (waterline, Model, assert, Errors, Promise, Constant
 
             switch(dbType) {
                 case 'mongo':
-                    return self.findAndModifyMongo(query, {}, { $set: { node: waterline.lookups.mongo.objectId(node)}}, options);
+                    return self.findAndModifyMongo(
+                        query,
+                        {},
+                        {
+                            $set: {
+                                node: waterline.lookups.mongo.objectId(node)
+                            }
+                        },
+                        options
+                    );
                 case 'postgresql':
                     return self.postgresqlRunLockedQuery('' +
-                        'WITH upsert AS (UPDATE lookups SET "node"= $1, "updatedAt" = $3 WHERE "macAddress" = $2 RETURNING *) ' +
+                        'WITH upsert AS (UPDATE lookups SET "node"= $1, "updatedAt" = $3 WHERE "macAddress" = $2 RETURNING *) ' + //jshint ignore: line
                         'INSERT INTO lookups ("macAddress", "node", "createdAt", "updatedAt") ' +
                         'SELECT  $2, $1, $4, $4 WHERE NOT EXISTS (SELECT * FROM upsert);',
                         [node, macAddress, new Date(), new Date()]);
@@ -101,7 +136,7 @@ function LookupModelFactory (waterline, Model, assert, Errors, Promise, Constant
             return self.findOne({ macAddress: macAddress }).then(function (record) {
                 if (record) {
                     return self.update(
-                        { id: record.id }, 
+                        { id: record.id },
                         { proxy: proxy }
                     ).then(function (records) {
                         return records[0];
@@ -166,30 +201,15 @@ function LookupModelFactory (waterline, Model, assert, Errors, Promise, Constant
 
         setIpPostgreSQL: function(ipAddress, macAddress) {
             var self = this;
-            return self.runQuery('UPDATE lookups SET "ipAddress" = $1 WHERE "macAddress" = $2;', [null, macAddress])
+            return self.runQuery('UPDATE lookups SET "ipAddress" = $1 WHERE "macAddress" = $2;', [null, macAddress]) //jshint ignore: line
             .then(function() {
                 return self.postgresqlRunLockedQuery('' +
-                    'WITH upsert AS (UPDATE lookups SET "ipAddress"= $1, "updatedAt"=$3 WHERE "macAddress"=$2 RETURNING *) ' +
+                    'WITH upsert AS (UPDATE lookups SET "ipAddress"= $1, "updatedAt"=$3 WHERE "macAddress"=$2 RETURNING *) ' + //jshint ignore: line
                     'INSERT INTO lookups ("macAddress", "ipAddress", "updatedAt", "createdAt" ) ' +
                     'SELECT  $2, $1, $4, $4 WHERE NOT EXISTS (SELECT * FROM upsert);',
                     [ipAddress, macAddress, new Date(), new Date() ]
                 );
             });
-        },
-
-        setIndexes: function() {
-            var indexes = [
-                {
-                    macAddress: 1
-                },
-                {
-                    macAddress: 1, ipAddress: 1
-                }
-            ];
-            if( dbType === 'mongo' ) {
-                return waterline.lookups.createUniqueMongoIndexes(indexes);
-            }
-            return Promise.resolve();
         }
     });
 }

--- a/lib/models/node.js
+++ b/lib/models/node.js
@@ -32,8 +32,7 @@ function NodeModelFactory (
     var attributes = {
         identifiers: {
             type: 'array',
-            required: false,
-            index: true
+            required: false
         },
         name: {
             type: 'string',
@@ -46,8 +45,7 @@ function NodeModelFactory (
         type: {
             type: 'string',
             enum: _.values(Constants.NodeTypes),
-            defaultsTo: 'compute',
-            index: true
+            defaultsTo: 'compute'
         },
         workflows: {
             collection: 'graphobjects',
@@ -117,6 +115,14 @@ function NodeModelFactory (
         connection: dbType,
         identity: 'nodes',
         attributes: attributes,
+        $indexes: [
+            {
+                keys: { identifiers: 1 }
+            },
+            {
+                keys: { type: 1 }
+            }
+        ],
         addTags: function(id, tags) {
             var self = this;
             var dbType = _.first(self.connection);
@@ -140,9 +146,10 @@ function NodeModelFactory (
                 // unfurl the JSON, merge with the request tag array, ensure uniqueness of entries,
                 // then JSONify the result set and update the tags entries with it.
                 return self.postgresqlRunLockedQuery('' +
-                    'WITH t as (select array_agg(elem::text) from nodes, json_array_elements(nodes.tags::json) elem where id = $2), ' +
+                    'WITH t as (select array_agg(elem::text) from nodes, json_array_elements(nodes.tags::json) elem where id = $2), ' + //jshint ignore: line
                     's as (select distinct unnest(array_cat(t.array_agg, ARRAY[$1])) from t) ' +
-                    'UPDATE nodes SET tags = concat( \'[\', (select string_agg(unnest,\',\') from s), \']\'),"updatedAt"=$3 WHERE id = $2',
+                    'UPDATE nodes SET tags = concat( \'[\', (select string_agg(unnest,\',\') from s), \']\'),"updatedAt"=$3 WHERE id = $2',//jshint ignore: line
+
                     [ '"' + tags.join('","') + '"', id, new Date()])
                 .then(function() {
                     return self.find({id: id})
@@ -179,9 +186,9 @@ function NodeModelFactory (
                 // unfurl the JSON, remove the entry from the array, ensure uniqueness of entries,
                 // then JSONify the result set and update the tags entries with it.
                 return self.postgresqlRunLockedQuery('' +
-                    'WITH t as (select array_agg(elem::text) from nodes, json_array_elements(nodes.tags::json) elem where id = $2), ' +
+                    'WITH t as (select array_agg(elem::text) from nodes, json_array_elements(nodes.tags::json) elem where id = $2), ' + //jshint ignore: line
                     's as (select distinct unnest(array_remove(t.array_agg, $1)) from t) ' +
-                    'UPDATE nodes SET tags = concat( \'[\', (select string_agg(unnest,\',\') from s), \']\'),"updatedAt"=$3 WHERE id = $2',
+                    'UPDATE nodes SET tags = concat( \'[\', (select string_agg(unnest,\',\') from s), \']\'),"updatedAt"=$3 WHERE id = $2', //jshint ignore: line
                     [ JSON.stringify(tag), id, new Date()])
                 .then(function() {
                     return self.findOne({id: id})

--- a/lib/models/obms.js
+++ b/lib/models/obms.js
@@ -83,7 +83,8 @@ function ObmsModelFactory (
         attributes: {
             node: {
                 model: 'nodes',
-                required: true
+                required: true,
+                unique: false
             },
             service: {
                 type: 'string',
@@ -99,6 +100,16 @@ function ObmsModelFactory (
             }
         },
 
+        $indexes: [
+            {
+                keys: { node: 1 }
+            },
+            {
+                keys: { node: 1, service: 1 },
+                options: { unique: true }
+            }
+        ],
+
         beforeCreate: function(attrs, next) {
             _encryptSecrets(attrs);
             next();
@@ -109,15 +120,6 @@ function ObmsModelFactory (
                 _encryptSecrets(attrs);
             }
             next();
-        },
-
-        setIndexes: function() {
-            var indexes = [
-                {
-                    node: 1, service: 1
-                }
-            ];
-            return waterline.obms.createUniqueMongoIndexes(indexes);
         },
 
         findByNode: function(nodeId, service, reveal, query) {

--- a/lib/models/renderable.js
+++ b/lib/models/renderable.js
@@ -22,7 +22,7 @@ function RenderableModelFactory (uuid) {
             name: {
                 type: 'string',
                 required: true,
-                index: true
+                unique: false //allow same file name but in different scope
             },
             hash: {
                 type: 'string',
@@ -36,6 +36,13 @@ function RenderableModelFactory (uuid) {
                 type: 'string',
                 defaultsTo: 'global'
             }
-        }
+        },
+
+        $indexes: [
+            {
+                keys: { name: 1, scope: 1 },
+                options: { unique: true }
+            }
+        ],
     };
 }

--- a/lib/models/roles.js
+++ b/lib/models/roles.js
@@ -28,17 +28,11 @@ function RolesModelFactory (waterline, Model, configuration) {
                 defaultsTo: []
             }
         },
-
-        setIndexes: function() {
-            var indexes = [
-                {
-                   role: 1
-                }
-            ];
-            if( dbType === 'mongo' ) {
-                return waterline.roles.createUniqueMongoIndexes(indexes);
+        $indexes: [
+            {
+                keys: { role: 1 },
+                options: { unique: true }
             }
-            return Promise.resolve();
-        }
+        ]
     });
 }

--- a/lib/models/sku.js
+++ b/lib/models/sku.js
@@ -43,8 +43,7 @@ function SkuModelFactory (Model, _, assert, Validatable, Anchor, configuration, 
             },
             name: {
                 type: 'string',
-                required: true,
-                index: true
+                required: true
             },
             rules: {
                 type: 'json',
@@ -85,6 +84,11 @@ function SkuModelFactory (Model, _, assert, Validatable, Anchor, configuration, 
             description : {
                 type: 'string'
             }
-        }
+        },
+        $indexes: [
+            {
+                keys: { name: 1 }
+            }
+        ]
     });
 }

--- a/lib/models/tags.js
+++ b/lib/models/tags.js
@@ -44,14 +44,18 @@ function TagModelFactory (Model, _, assert, Validatable, Anchor, configuration, 
             },
             name: {
                 type: 'string',
-                required: true,
-                index: true
+                required: true
             },
             rules: {
                 type: 'json',
                 tagRules: true,
                 required: true
             }
-        }
+        },
+        $indexes: [
+            {
+                keys: { name: 1 }
+            }
+        ]
     });
 }

--- a/lib/models/task-definition.js
+++ b/lib/models/task-definition.js
@@ -22,7 +22,7 @@ function TaskModelFactory (Model, configuration) {
             injectableName: {
                 type: 'string',
                 required: true,
-                unique: true,
+                unique: true
             },
             implementsTask: {
                 type: 'string',
@@ -49,6 +49,12 @@ function TaskModelFactory (Model, configuration) {
                 delete obj.id;
                 return obj;
             }
-        }
+        },
+        $indexes: [
+            {
+                keys: { injectableName: 1 },
+                options: { unique: true }
+            }
+        ]
     });
 }

--- a/lib/models/task-dependency.js
+++ b/lib/models/task-dependency.js
@@ -70,6 +70,13 @@ function TaskDependencyFactory (Model, Constants, configuration) {
                 delete obj.id;
                 return obj;
             }
-        }
+        },
+
+        $indexes: [
+            {
+                keys: { taskId: 1, graphId: 1 },
+                options: { unique: true }
+            }
+        ]
     });
 }

--- a/lib/models/work-item.js
+++ b/lib/models/work-item.js
@@ -32,7 +32,8 @@ function WorkItemModelFactory (
     // but only on-http and on-taskgraph reference the workflowInjectables where TaskGraph.Store
     // is contained.  Because of this, we cannot reference TaskGraph.Store directly in the $inject
     // list and have to pull it in here
-    var taskGraphStore = injector._hasProviderFor('TaskGraph.Store') ? injector.get('TaskGraph.Store') : null;
+    var taskGraphStore =
+        injector._hasProviderFor('TaskGraph.Store') ? injector.get('TaskGraph.Store') : null;
 
     function getAdjustedInterval(workitem) {
         return Math.min(
@@ -47,11 +48,13 @@ function WorkItemModelFactory (
         attributes: {
             name: {
                 type: 'string',
-                required: true
+                required: true,
+                unique: false
             },
             node: {
                 model: 'nodes',
-                defaultsTo: null
+                defaultsTo: null,
+                unique: false
             },
             config: {
                 type: 'json',
@@ -63,7 +66,8 @@ function WorkItemModelFactory (
             },
             nextScheduled: {
                 type: 'datetime',
-                defaultsTo: null
+                defaultsTo: null,
+                unique: false
             },
             lastStarted: {
                 type: 'datetime',
@@ -106,6 +110,21 @@ function WorkItemModelFactory (
             }
         },
 
+        $indexes: [
+            {
+                keys: { name: 1 }
+            },
+            {
+                keys: { node: 1 }
+            },
+            {
+                keys: { nextScheduled: 1 }
+            },
+            {
+                keys: { node: 1, name: 1 }
+            }
+        ],
+
         startNextScheduled: function startNextScheduled(leaseToken, criteria, leaseDuration) {
             var self = this;
             return taskGraphStore.checkoutTimer(leaseToken, criteria, leaseDuration)
@@ -137,8 +156,8 @@ function WorkItemModelFactory (
                 }
                 var nextScheduled = new Date(now.valueOf() + getAdjustedInterval(workItem));
                 return taskGraphStore.updatePollerStatus(workItem.id, {
-                    status: Constants.Task.States.Failed, 
-                    nextScheduled: nextScheduled, 
+                    status: Constants.Task.States.Failed,
+                    nextScheduled: nextScheduled,
                     lastFinished: now,
                     state: newState
                 });
@@ -166,8 +185,8 @@ function WorkItemModelFactory (
                 }
                 var nextScheduled = new Date(now.valueOf() + workItem.pollInterval);
                 return taskGraphStore.updatePollerStatus(workItem.id, {
-                    status: Constants.Task.States.Succeeded, 
-                    nextScheduled: nextScheduled, 
+                    status: Constants.Task.States.Succeeded,
+                    nextScheduled: nextScheduled,
                     lastFinished: now,
                     state: newState
                 });

--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -513,9 +513,7 @@ function lookupServiceFactory(
         });
     };
 
-    LookupService.prototype.start = function () {
-        return waterline.lookups.setIndexes();
-    };
+    LookupService.prototype.start = function () {};
 
     LookupService.prototype.stop = function () {
         return Promise.resolve();

--- a/lib/services/waterline.js
+++ b/lib/services/waterline.js
@@ -36,12 +36,7 @@ function WaterlineServiceFactory(
         return this.initialized;
     };
 
-    /**
-     * Initializes waterline and loads waterline models.
-     *
-     * @returns {Promise.promise}
-     */
-    WaterlineService.prototype.start = function () {
+    WaterlineService.prototype.initService = function() {
         var self = this;
 
         return new Promise(function (resolve, reject) {
@@ -50,7 +45,7 @@ function WaterlineServiceFactory(
                 configuration.get('taskgraph-store', 'mongo')
             ];
             var allowedDbTypes = ['mongo', 'postgresql'];
-            assert.ok(_(_.difference(dbTypes, allowedDbTypes)).isEmpty(), 
+            assert.ok(_(_.difference(dbTypes, allowedDbTypes)).isEmpty(),
                 'invalid dbType:' + _.difference(dbTypes, allowedDbTypes).toString());
 
             var mongoCfg = {
@@ -73,14 +68,15 @@ function WaterlineServiceFactory(
                     postgresql: {
                         adapter: 'postgresql',
                         module: 'postgresql',
-                        url: configuration.get('postgresql', 'postgres://rackhd:rackhd@localhost:5432/pxe'),
+                        url: configuration.get('postgresql',
+                                'postgres://rackhd:rackhd@localhost:5432/pxe'),
                         poolSize: 10,
                         ssl: false
                     }
                 }
             };
 
-            self.config = _.merge({},
+            var config = _.merge({},
                 (-1 !== _.indexOf(dbTypes, 'mongo')) ? mongoCfg : {},
                 (-1 !== _.indexOf(dbTypes, 'postgresql')) ? postgreSqlCfg : {},
                 {
@@ -89,34 +85,52 @@ function WaterlineServiceFactory(
                     }
                 });
 
-            if (self.isInitialized()) {
-                resolve(self);
-            } else {
-                // Match out Waterline.Models.* and load them into waterline.
-                injector.getMatching('Models.*').forEach(function (model) {
-                    self.service.loadCollection(model);
-                });
+            // Match out Waterline.Models.* and load them into waterline.
+            injector.getMatching('Models.*').forEach(function (model) {
+                self.service.loadCollection(model);
+            });
 
-                // Initialize waterline and save the ontology while adding
-                // convenience methods for accessing the models via the
-                // collections.
-                self.service.initialize(self.config, function (error, ontology) {
-                    if (error) {
-                        reject(error);
-                    } else {
-                        _.forOwn(ontology.collections, function (collection, name) {
-                            self[name] = collection;
-                            if (typeof(collection.setIndexes) === 'function') {
-                                collection.setIndexes();
-                            }
-                        });
+            // Initialize waterline and save the ontology while adding
+            // convenience methods for accessing the models via the
+            // collections.
+            self.service.initialize(config, function (error, ontology) {
+                if (error) {
+                    reject(error);
+                } else {
+                    _.forOwn(ontology.collections, function (collection, name) {
+                        self[name] = collection;
+                    });
+                    self.ontology = ontology;
+                    resolve(self);
+                }
+            });
+        });
+    };
 
-                        self.initialized = true;
+    /**
+     * Initializes waterline and loads waterline models.
+     *
+     * @returns {Promise.promise}
+     */
+    WaterlineService.prototype.start = function () {
+        var self = this;
 
-                        resolve(self);
-                    }
+        return Promise.resolve().then(function() {
+            if (!self.isInitialized()) {
+                return self.initService().then(function() {
+                    self.initialized = true;
                 });
             }
+        })
+        .then(function() {
+            //it's OK to create indexes multiple times, so the code isn't protected by initialized
+            //checking.
+            return Promise.map(_.values(self.ontology.collections), function (collection) {
+                return collection.createIndexes();
+            });
+        })
+        .then(function() {
+            return self;
         });
     };
 

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -65,21 +65,6 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
     };
 
     /**
-     * @param {Object} indexObject an object with keys that correspond to the mogo
-     * collections on which to place indexes and values that are arrays of indexes
-     * @memberOf store
-     * @returns {Promise}
-     */
-    exports.setIndexes = function(indexObject) {
-        return Promise.all(_.flatten(_.map(indexObject, function(indexObj, key) {
-                return _.map(indexObj, function(index) {
-                    return waterline[key].createMongoIndexes(index);
-                });
-            }))
-        );
-    };
-
-    /**
      * Sets the state of a reachable, matching task in the taskdependencies collection
      * and updates the task's context.
      * @param {Object} task - a task object

--- a/spec/lib/common/model-spec.js
+++ b/spec/lib/common/model-spec.js
@@ -22,8 +22,24 @@ describe('Model', function () {
             attributes: {
                 dummy: {
                     type: 'string'
+                },
+                foo: {
+                    type: 'string',
+                    unique: true
+                },
+                bar: {
+                    type: 'string',
                 }
-            }
+            },
+            $indexes: [
+                {
+                    keys: { foo: 1, bar: 1 },
+                },
+                {
+                    keys: { foo: 1 },
+                    options: { unique: false }
+                }
+            ]
         });
     }
 
@@ -768,6 +784,21 @@ describe('Model', function () {
                 expect(waterline.testobjects.runNativeMongo).to.have.been.calledWith(
                     'createIndex',
                     [ indexes[1], { unique: true } ]
+                );
+            });
+        });
+
+        it('should have a createIndexes method that calls the runNativeMongo method', function() {
+            return waterline.testobjects.createIndexes()
+            .then(function() {
+                expect(waterline.testobjects.runNativeMongo).to.have.been.calledTwice;
+                expect(waterline.testobjects.runNativeMongo).to.have.been.calledWith(
+                    'createIndex',
+                    [ { foo: 1, bar: 1 }, { } ]
+                );
+                expect(waterline.testobjects.runNativeMongo).to.have.been.calledWith(
+                    'createIndex',
+                    [ { foo: 1 }, { unique: false } ] //index in $indexes will take precedent
                 );
             });
         });

--- a/spec/lib/models/base-spec.js
+++ b/spec/lib/models/base-spec.js
@@ -68,6 +68,30 @@ module.exports = {
                     expect(this.subject.type).to.equal('datetime');
                 });
             });
+
+            describe('$indexes', function () {
+                before(function () {
+                    this.subject = this.$indexes;
+                });
+
+                it('should be an array of valid object', function () {
+                    if (!this.subject) { //$indexes is optional
+                        return;
+                    }
+
+                    expect(this.subject).to.be.instanceof(Array);
+                    _.forEach(this.subject, function(item) {
+                        expect(item).to.be.an('Object');
+                        expect(item).to.have.any.keys('keys', 'options'); //not allow others keys
+                        expect(item).to.have.all.keys('keys'); //keys is must-have
+                        expect(item.keys).to.be.an('Object');
+                        expect(item.keys).to.not.deep.equal({}); //cannot be empty object
+                        if (item.options) {
+                            expect(item.options).to.be.an('Object');
+                        }
+                    });
+                });
+            });
         });
 
         describe('Class Methods', function () {
@@ -118,6 +142,16 @@ module.exports = {
 
                 it('should be a function', function () {
                     expect(this.model).to.respondTo('findMostRecent');
+                });
+            });
+
+            describe('createIndexes', function () {
+                it('should exist', function () {
+                    expect(this.model.createIndexes).to.exist;
+                });
+
+                it('should be a function', function () {
+                    expect(this.model).to.respondTo('createIndexes');
                 });
             });
         });

--- a/spec/lib/models/lookup-spec.js
+++ b/spec/lib/models/lookup-spec.js
@@ -49,10 +49,6 @@ describe('Models.Lookup', function () {
             it('should be a string', function () {
                 expect(this.subject.type).to.equal('string');
             });
-
-            it('should be unique', function() {
-                expect(this.subject.unique).to.equal(true);
-            });
         });
 
         describe('macAddress', function () {
@@ -192,8 +188,10 @@ describe('Models.Lookup', function () {
                     expect(waterline.lookups.findAndModifyMongo).to.have.been.calledOnce;
                     var query = { macAddress: 'macAddress' };
                     var update = { $set: { node:  waterline.lookups.mongo.objectId('node') }};
-                    expect(waterline.lookups.findAndModifyMongo.firstCall.args[0]).to.deep.equal(query);
-                    expect(waterline.lookups.findAndModifyMongo.firstCall.args[2]).to.deep.equal(update);
+                    expect(waterline.lookups.findAndModifyMongo.firstCall.args[0])
+                        .to.deep.equal(query);
+                    expect(waterline.lookups.findAndModifyMongo.firstCall.args[2])
+                        .to.deep.equal(update);
                 });
             });
         });
@@ -299,26 +297,5 @@ describe('Models.Lookup', function () {
                 });
             });
         });
-
-        describe('setIndexes', function () {
-            it('should set unique indexes', function() {
-                this.sandbox.stub(waterline.lookups, 'createUniqueMongoIndexes').resolves();
-
-                return waterline.lookups.setIndexes().then(function () {
-                    expect(waterline.lookups.createUniqueMongoIndexes)
-                        .to.have.been.calledOnce;
-                    expect(waterline.lookups.createUniqueMongoIndexes)
-                        .to.have.been.calledWith([
-                            {
-                                macAddress: 1
-                            },
-                            {
-                                macAddress: 1, ipAddress: 1
-                            }
-                        ]);
-                });
-            });
-        });
-
     });
 });

--- a/spec/lib/models/obms-spec.js
+++ b/spec/lib/models/obms-spec.js
@@ -39,7 +39,6 @@ describe('Models.Obms', function () {
     before(function() {
         encryption = helper.injector.get('Services.Encryption');
         Constants = helper.injector.get('Constants');
-        return obms.setIndexes();
     });
 
     beforeEach(function() {

--- a/spec/lib/models/roles-spec.js
+++ b/spec/lib/models/roles-spec.js
@@ -75,28 +75,5 @@ describe('Models.Roles', function () {
                 expect(this.subject.type).to.equal('array');
             });
         });
-
-        describe('setIndexes', function () {
-            var waterline;
-
-            before(function () {
-                waterline = helper.injector.get('Services.Waterline');
-            });
-
-            it('should set unique indexes', function() {
-                this.sandbox.stub(waterline.roles, 'createUniqueMongoIndexes').resolves();
-
-                return waterline.roles.setIndexes().then(function () {
-                    expect(waterline.roles.createUniqueMongoIndexes)
-                        .to.have.been.calledOnce;
-                    expect(waterline.roles.createUniqueMongoIndexes)
-                        .to.have.been.calledWith([
-                            {
-                                role: 1
-                            }
-                        ]);
-                });
-            });
-        });
     });
 });

--- a/spec/lib/services/waterline-spec.js
+++ b/spec/lib/services/waterline-spec.js
@@ -25,13 +25,23 @@ describe('Services.Waterline', function () {
 
     describe('start', function () {
         it('should start service and resolve', function() {
+            var createIndexesStub = this.sandbox.stub().resolves();
             waterline.service.initialize = this.sandbox.spy(function(cfg,callback) {
-                var ontology = {collections:{model:'model'}};
-                callback(undefined,ontology);
+                var ontology = {
+                    collections:{
+                        'testModel': {
+                            identity: 'test',
+                            createIndexes: createIndexesStub
+                        }
+                    }
+                };
+                callback(undefined, ontology);
             });
-            return waterline.start().should.be.resolved;
+            return waterline.start().then(function() {
+                expect(createIndexesStub).to.have.been.called;
+            });
         });
-        
+
         it('should resolve itself if already initialized', function() {
             this.sandbox.stub(waterline, 'isInitialized').returns(true);
             return waterline.start().should.be.resolved;
@@ -45,7 +55,7 @@ describe('Services.Waterline', function () {
             return waterline.start().should.be.rejected;
         });
     });
-  
+
     describe('stop', function () {
         it('should teardown and resolve when initialized', function() {
             waterline.service.teardown = this.sandbox.spy(function(callback) {
@@ -54,12 +64,12 @@ describe('Services.Waterline', function () {
             this.sandbox.stub(waterline, 'isInitialized').returns(true);
             return waterline.stop();
         });
-        
+
         it('should resolve when not initialized', function() {
             this.sandbox.stub(waterline, 'isInitialized').returns(false);
             return waterline.stop();
         });
     });
-    
+
 });
 

--- a/spec/lib/workflow/stores/mongo-spec.js
+++ b/spec/lib/workflow/stores/mongo-spec.js
@@ -701,20 +701,6 @@ describe('Task Graph mongo store interface', function () {
         });
     });
 
-    it('setIndexes', function() {
-        var indexObject = {
-            taskdependencies: [
-                {taskId: 1, graphId: 1}
-            ]
-        };
-
-        return mongo.setIndexes(indexObject)
-        .then(function() {
-            expect(waterline.taskdependencies.createMongoIndexes).to.be
-                .calledWithExactly({taskId: 1, graphId: 1});
-        });
-    });
-
     it('findChildGraph', function() {
         var runGraphTaskId = uuid.v4();
         return mongo.findChildGraph(runGraphTaskId)


### PR DESCRIPTION
This PR originates from ODR-892 (https://hwjiraprd01.corp.emc.com/browse/ODR-892), @cgx027 found two problems about mongo index:
(1) some index settings in our code doesn't take effect.
(2) lack index for some frequently operation

I also found the waterline official doc said there is some outstanding bug about index, see https://github.com/balderdashy/waterline-docs/blob/master/models/data-types-attributes.md#index, meanwhile, the waterline doesn't support compound index.

I see some models (such as obm/lookups) will manually create mongo index, but most other models don't do this way.

This PR is to let the mongo index creation take effect for all models. The index can be defined in following two ways:
(1) In waterline attributes, if the `index` is set to `true`, code will auto extract the index and create it regardless waterline's internal operation.
```
attributes: {
    name: {
        type: 'string',
        index: true
    }
}
```

(2) Use magic option `$indexes` for model, this will take precedent comparing with above. Meanwhile, this can be used to set compound index.
```
$indexes: [
    {
        keys: { foo: 1, bar: 1 }
        options: { unique: true }
    },
    {
        keys: { x: 1, y: 1, z: -1 }
    }
]
```

@RackHD/corecommitters @cgx027 @iceiilin @keedya @VulpesArtificem 

jenkins: depends on https://github.com/RackHD/on-taskgraph/pull/188