### PR TITLE
Reverted Encryption at mongo store level, refactored Sanitizer Object.

### DIFF
--- a/lib/common/model.js
+++ b/lib/common/model.js
@@ -14,8 +14,7 @@ ModelFactory.$inject = [
     'Errors',
     'Waterline',
     'Protocol.Waterline',
-    'Services.Waterline',
-    'Sanitizer'
+    'Services.Waterline'
 ];
 
 function ModelFactory (
@@ -27,8 +26,7 @@ function ModelFactory (
     Errors,
     Waterline,
     waterlineProtocol,
-    waterline,
-    sanitizer
+    waterline
 ) {
     var url = require('url');
 
@@ -196,9 +194,6 @@ function ModelFactory (
                 args.shift();
             }
             var update = args.shift();
-
-            // encrypt password fields
-            sanitizer.encrypt(update);
 
             // Don't validate if we're setting/unsetting individual properties
             if (update.$set || update.$setOnInsert) {

--- a/lib/common/sanitizer.js
+++ b/lib/common/sanitizer.js
@@ -30,23 +30,12 @@ function SanitizerFactory (
             if (typeof(value) === 'object') {
                 sanitizer(value);
             } else if ( key.match( secretsRegex )) {
-                obj[key] = encryption.encrypt(value);
-            }
-        });
-    }
-
-    function de_sanitizer (obj) {
-        _.forOwn(obj, function(value, key) {
-            if (typeof(value) === 'object') {
-                de_sanitizer(value);
-            } else if ( key.match( secretsRegex )) {
-                obj[key] = encryption.decrypt(value);
+                obj[key] = 'REDACTED';
             }
         });
     }
 
     return {
-        encrypt: sanitizer,
-        decrypt: de_sanitizer
+        scrub: sanitizer,
     }
 }

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -9,11 +9,10 @@ mongoStoreFactory.$inject = [
     'Constants',
     'Errors',
     'Assert',
-    '_',
-    'Sanitizer'
+    '_'
 ];
 
-function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _, sanitizer) {
+function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
     var exports = {};
 
     exports.publishRecordByGraphId = function (graphId, event) {
@@ -371,8 +370,6 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _, san
 
         return waterline.graphobjects.findOne(query, options)
         .then(function(graph) {
-            sanitizer.decrypt(graph.tasks[data.taskId]);
-            sanitizer.decrypt(graph.context);
             return {
                 graphId: graph.instanceId,
                 context: graph.context,

--- a/spec/lib/common/sanitizer-spec.js
+++ b/spec/lib/common/sanitizer-spec.js
@@ -24,25 +24,14 @@ describe('Sanitizer', function () {
         };
     });
 
-    it ('it encrypts first level', function () {
-        sanitizer.encrypt(graphObj);
+    it ('it removes passwords at  first level', function () {
+        sanitizer.scrub(graphObj);
         expect(graphObj.password).to.not.equal('testPassword');
     });
 
-    it ('it encrypts nested levels', function () {
-        sanitizer.encrypt(graphObj);
+    it ('it removes passwords at  nested levels', function () {
+        sanitizer.scrub(graphObj);
         expect(graphObj.definition.options.test_task.password).to.not.equal('foo');
     });
 
-    it ('it decrypts as expected first level', function () {
-        sanitizer.encrypt(graphObj);
-        sanitizer.decrypt(graphObj);
-        expect(graphObj.password).to.equal('testPassword');
-    });
-
-    it ('it decrypts as expected nested levels', function () {
-        sanitizer.encrypt(graphObj);
-        sanitizer.decrypt(graphObj);
-        expect(graphObj.definition.options.test_task.password).to.equal('foo');
-    });
 });


### PR DESCRIPTION
@RackHD/corecommitters 

Ok, so this guts the existing encryption I introduced... and I refactored the sanitizer object to serve up a single method that can be used to recursively redact secret fields... this PR will have a dependent PR within on-http to resolve the original issue:  https://github.com/RackHD/RackHD/issues/241

