### PR TITLE
RAC-170: RackHD support for multiple AMQP servers

### DIFF
--- a/lib/common/messenger.js
+++ b/lib/common/messenger.js
@@ -92,8 +92,13 @@ function messengerFactory(
             options = {
                 url: uri
             };
-        } else {
+        } else if (Array.isArray(uri)) {
             options = uri;
+        } else {
+            console.log('Setting AMQP URL to localhost');
+            options = {
+                url: 'amqp://localhost'
+            };
         }
 
         var clientOptions = {

--- a/lib/common/messenger.js
+++ b/lib/common/messenger.js
@@ -86,9 +86,16 @@ function messengerFactory(
 
         assert.ok(uri, 'uri');
 
-        var options = {
-            url: uri
-        };
+        var options;
+
+        if (typeof uri === 'string') {
+            options = {
+                url: uri
+            };
+        } else {
+            options = uri;
+        }
+
         var clientOptions = {
             reconnect: true,
             reconnectBackoffStrategy: 'linear',


### PR DESCRIPTION
Modified RackHD on-core to allow an array of AMQP server IP addresses as an option during the AMQP connection call.