### PR TITLE
modify queue name for messenger request function

### DIFF
--- a/lib/common/messenger.js
+++ b/lib/common/messenger.js
@@ -295,14 +295,18 @@ function messengerFactory(
         return new Promise(function (resolve, reject) {
             context.resolve = resolve;
             context.reject = reject;
-            self.receive.queue(queueName(name, routingKey), queueOptions, function (q) {
-                context.queue = q;
-                q.subscribe(
-                    subscribeOptions,
-                    self.subscribeTimeout.bind(self, context)
-                )
-                .addCallback(self.subscribeCallback.bind(self, context));
-            });
+            self.receive.queue(
+                queueName(name, routingKey + '.request'),
+                queueOptions,
+                function (q) {
+                    context.queue = q;
+                    q.subscribe(
+                        subscribeOptions,
+                        self.subscribeTimeout.bind(self, context)
+                    )
+                    .addCallback(self.subscribeCallback.bind(self, context));
+                }
+            );
         });
     };
 


### PR DESCRIPTION
"request" mechanism
---
in request function, both requester and responder use a queue to receive messages from their counterpart. In current code, the queue is exclusive, which means that it can only be acquired by one channel. Their names are in the same format "exchange:method.id:randomId"

problem
---
It is found that in scale environment (power on 350 nodes for discovery in an interval of 10s, host of rackhd 8G&4core), at a rate about 1/3, on-http (requester) tries to use a queue for taskExist message that is already owned by on-taskgraph (responder). the third-party shortId module for randomId generation is the most suspicious.

when this error occurs,
rabbitmq server repeats the following error
```
=INFO REPORT==== 11-Feb-2016::19:11:03 ===
accepting AMQP connection <0.17948.23> (127.0.0.1:48758 -> 127.0.0.1:5672)

=ERROR REPORT==== 11-Feb-2016::19:11:03 ===
Channel error on connection <0.17948.23> (127.0.0.1:48758 -> 127.0.0.1:5672, vhost: '/', user: 'guest'), channel 12933:
{amqp_error,resource_locked,
            "cannot obtain exclusive access to locked queue 'on.task:methods.activeTaskExists.56bcd84a9004a63d06941528:Byv' in vhost '/'",
            'queue.declare'}

=WARNING REPORT==== 11-Feb-2016::19:11:03 ===
closing AMQP connection <0.17948.23> (127.0.0.1:48758 -> 127.0.0.1:5672):
connection_closed_abruptly
```
and on-http continuesly tries to create a new connections and declare this queue. As a result, rabbitmq server consumes increasing amount of memory, and is killed by OS finally.

solution
---
To avoid this problem, adding ".request" to the queue name of requester, which differentiate queue names of these two parts. and this problem disappears.