### PR TITLE
The first version of splitting external events with different publish method

### DIFF
--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -11,8 +11,7 @@ eventsProtocolFactory.$inject = [
     'Services.Messenger',
     'Promise',
     'validator',
-    'Assert',
-    'Errors'
+    'Assert'
 ];
 
 function eventsProtocolFactory (
@@ -21,8 +20,7 @@ function eventsProtocolFactory (
     messenger,
     Promise,
     validator,
-    assert,
-    Error
+    assert
 ) {
     function EventsProtocol () {
     }
@@ -31,7 +29,7 @@ function eventsProtocolFactory (
         assert.string(nodeId);
         assert.object(data);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'tftp.success' + '.' + nodeId,
             data
@@ -53,7 +51,7 @@ function eventsProtocolFactory (
         assert.string(nodeId);
         assert.object(data);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'tftp.failure' + '.' + nodeId,
             data
@@ -75,7 +73,7 @@ function eventsProtocolFactory (
         assert.string(nodeId);
         assert.object(data);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'http.response' + '.' + nodeId,
             data
@@ -98,7 +96,7 @@ function eventsProtocolFactory (
         assert.string(nodeId);
         assert.object(data);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'dhcp.bind.success' + '.' + nodeId,
             data
@@ -125,7 +123,7 @@ function eventsProtocolFactory (
         assert.object(context);
         assert.arrayOfString(terminalOnStates);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             domain + '.' + 'task.finished',
             { taskId: taskId, graphId: graphId, state: state, error: error,
@@ -145,7 +143,7 @@ function eventsProtocolFactory (
     };
 
     EventsProtocol.prototype.publishNodeNotification = function (nodeId, data) {
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'notification' + '.' + nodeId,
             data || ''
@@ -163,7 +161,7 @@ function eventsProtocolFactory (
     };
 
     EventsProtocol.prototype.publishBroadcastNotification = function (data) {
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'notification',
             data || ''
@@ -183,7 +181,7 @@ function eventsProtocolFactory (
     EventsProtocol.prototype.publishGraphStarted = function (graphid, data) {
         assert.uuid(graphid);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'graph.started' + '.' + graphid,
             data || {}
@@ -207,7 +205,7 @@ function eventsProtocolFactory (
         assert.uuid(graphid);
         assert.string(status);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'graph.finished' + '.' + graphid,
             { status: status }
@@ -231,7 +229,7 @@ function eventsProtocolFactory (
         assert.isMongoId(nodeId);
         assert.uuid(skuId);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'sku.assigned' + '.' + nodeId,
             { sku: skuId }
@@ -252,7 +250,7 @@ function eventsProtocolFactory (
     };
 
     EventsProtocol.prototype.publishIgnoredError = function (error) {
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             Constants.Events.Ignored,
             error
@@ -260,7 +258,7 @@ function eventsProtocolFactory (
     };
 
     EventsProtocol.prototype.publishUnhandledError = function (error) {
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             Constants.Events.Unhandled,
             error
@@ -268,7 +266,7 @@ function eventsProtocolFactory (
     };
 
     EventsProtocol.prototype.publishBlockedEventLoop = function (e) {
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             Constants.Events.Blocked,
             e
@@ -279,11 +277,12 @@ function eventsProtocolFactory (
         assert.object(data);
         assert.string(data.type);
 
-        return messenger.publish(
-            Constants.Protocol.Exchanges.Events.Name,
-            'event' + '.' + data.type,
-            data
-        );
+        return messenger.publishExternalEvents(
+                Constants.Protocol.Exchanges.Events.Name,
+                'event' + '.' + data.type,
+                 data
+             );
+
     };
 
     EventsProtocol.prototype.publishNodeEvent = function (node, action, data) {
@@ -295,12 +294,11 @@ function eventsProtocolFactory (
             type: 'node',
             action: action,
             nodeId: node.id,
-            nodeType: node.type
+            nodeType: node.type,
+            typeId: node.id
         };
 
-        if(data){
-            nodeEvent.data = data;
-        }
+        nodeEvent.payload = data || null;
 
         return self.publishEvent(nodeEvent);
     };
@@ -333,7 +331,7 @@ function eventsProtocolFactory (
         assert.object(data);
         assert.string(data.graphId);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             'graph.progress' + '.' + data.graphId,
             data

--- a/lib/protocol/scheduler.js
+++ b/lib/protocol/scheduler.js
@@ -18,7 +18,7 @@ function schedulerProtocolFactory (messenger, Constants, assert) {
     SchedulerProtocol.prototype.schedule = function(taskId, taskName, overrides) {
         assert.uuid(taskId);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Scheduler.Name,
             'schedule',
             { taskId: taskId, taskName: taskName, overrides: overrides }

--- a/lib/protocol/task-graph-runner.js
+++ b/lib/protocol/task-graph-runner.js
@@ -231,7 +231,7 @@ function taskGraphRunnerProtocolFactory (
     TaskGraphRunnerProtocol.prototype.runTaskGraph = function (graphId, domain) {
         assert.uuid(graphId);
         domain = domain || Constants.Task.DefaultDomain;
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.TaskGraphRunner.Name,
             'methods.runTaskGraph' + '.' + domain,
             { graphId: graphId }

--- a/lib/protocol/task.js
+++ b/lib/protocol/task.js
@@ -22,7 +22,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
     TaskProtocol.prototype.run = function (domain, data) {
         assert.string(domain);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             domain + '.' + 'methods.run',
             data || {}
@@ -43,7 +43,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
     TaskProtocol.prototype.cancel = function (taskId) {
         assert.uuid(taskId);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             'methods.cancel',
             { taskId: taskId }
@@ -165,7 +165,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
     TaskProtocol.prototype.respondCommands = function respondCommands(id, data) {
         assert.string(id);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             'methods.respondCommands' + '.' + id,
             new Result({ value: data })
@@ -292,7 +292,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         assert.string(command);
         assert.object(data);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             ['ipmi', 'command', command, uuid].join('.'),
             new Result({ value: data })
@@ -332,7 +332,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         assert.string(command);
         assert.ok(result);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             ['ipmi', 'command', command, 'result', uuid].join('.'),
             new Result({ value: result })
@@ -343,7 +343,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         assert.uuid(uuid, 'routing key uuid suffix');
         assert.object(data);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             'run.snmp.command' + '.' + uuid,
             new Result({ value: data })
@@ -380,7 +380,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         assert.uuid(uuid, 'routing key uuid suffix');
         assert.object(results);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             'snmp.command.result' + '.' + uuid,
             new Result({ value: results })
@@ -407,7 +407,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         assert.string(name);
         assert.object(result);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             ['metric', name, 'result', uuid].join('.'),
             new Result({ value: result })
@@ -420,7 +420,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         assert.string(pollerName, 'poller name suffix');
         assert.object(results);
 
-        return messenger.publish(
+        return messenger.publishExternalEvents(
             Constants.Protocol.Exchanges.Events.Name,
             ['poller.alert', pollerName, uuid].join('.'),
             new Result({ value: results })
@@ -464,7 +464,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         assert.uuid(uuid, 'routing key uuid suffix');
         assert.object(data);
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             'run.ansible.command' + '.' + uuid,
             new Result({ value: data })
@@ -489,7 +489,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         assert.string(type, 'trigger type');
         assert.string(group, 'trigger group');
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Task.Name,
             'trigger' + '.' + uuid + '.' + group + '.' + type,
             {}

--- a/lib/protocol/waterline.js
+++ b/lib/protocol/waterline.js
@@ -25,7 +25,7 @@ function waterlineProtocolFactory (_, assert, Constants, messenger) {
         id = id || record.id;
         var routingKey = collection.identity + '.' + event + '.' + id;
 
-        return messenger.publish(
+        return messenger.publishInternalEvents(
             Constants.Protocol.Exchanges.Waterline.Name,
             routingKey,
             {

--- a/lib/services/heartbeat.js
+++ b/lib/services/heartbeat.js
@@ -30,7 +30,7 @@ function heartbeatServiceFactory(
 
     function HeartbeatService () {
         this.intervalSec = parseInt(configuration.get(
-            'heartbeatIntervalSec', 
+            'heartbeatIntervalSec',
             Constants.Heartbeat.defaultIntervalSec
         ));
         this.name = Constants.Name;
@@ -45,18 +45,18 @@ function heartbeatServiceFactory(
             memoryUsage: process.memoryUsage()
         };
     }
-    
+
     HeartbeatService.prototype.requireDns = function() {
         return Promise.promisifyAll(require('dns'));
     };
-    
+
     HeartbeatService.prototype.getCpuUsage = function() {
         if(process.cpuUsage) {
             return process.cpuUsage(this.startCpuUsage);
         }
         return 'NA'; // Added in: v6.1.0
     };
-        
+
     HeartbeatService.prototype.getFqdn = Promise.method(function() {
         var self = this;
         var dns = self.requireDns();
@@ -65,7 +65,7 @@ function heartbeatServiceFactory(
             .then(dns.lookupAsync)
             .then(function(ip) {
                 return dns.lookupServiceAsync(ip[0], 0)
-                .then(function(fqdn, service) {
+                .then(function(fqdn) {
                     return fqdn[0];
                 });
             })
@@ -75,17 +75,23 @@ function heartbeatServiceFactory(
         }
         return Constants.Host;
     });
-    
+
     HeartbeatService.prototype.isRunning = function() {
         return this.running;
     };
-    
+
     HeartbeatService.prototype.sendHeartbeat = function() {
         var self = this;
-        return messenger.publish(
+        var data = {
+            type: "service",
+            typeId: "heartbeat",
+            action: "heartbeat.updated",
+            payload: self.info
+         };
+        return messenger.publishExternalEvents(
             Constants.Protocol.Exchanges.Heartbeat.Name,
-            self.routingKey, 
-            new Result({value: self.info})
+            self.routingKey,
+            data
         )
         .then(function() {
             self.lastUpdate = self.info.currentTime;
@@ -106,7 +112,7 @@ function heartbeatServiceFactory(
                         self.info.nextUpdate = new Date(
                             self.info.currentTime.valueOf() + self.intervalSec * 1000
                         );
-                        self.info.lastUpdate = self.lastUpdate
+                        self.info.lastUpdate = self.lastUpdate;
                         self.info.memoryUsage = process.memoryUsage();
                         self.info.cpuUsage = self.getCpuUsage();
                         self.sendHeartbeat();

--- a/lib/services/messenger.js
+++ b/lib/services/messenger.js
@@ -6,9 +6,87 @@ module.exports = messengerServiceFactory;
 
 messengerServiceFactory.$provide = 'Services.Messenger';
 messengerServiceFactory.$inject = [
-    'Messenger'
+    'Messenger',
+    'Assert'
+
 ];
 
-function messengerServiceFactory(Messenger) {
-    return new Messenger();
+function messengerServiceFactory(
+    Messenger,
+    assert
+) {
+    function MessengerService(){
+        this.messenger = new Messenger();
+    }
+
+    MessengerService.prototype.validate = function validate(data) {
+	return this.messenger.validate(data);
+    };
+
+    MessengerService.prototype.queueName = function queueName(name, routingKey){
+	return this.messenger.queueName(name, routingKey);
+    };
+
+    MessengerService.prototype.start = function start() {
+        return this.messenger.start();
+    };
+
+    MessengerService.prototype.stop = function stop() {
+        return this.messenger.stop();
+    };
+
+    MessengerService.prototype.publishExternalEvents  = function(
+        name, routingKey, data, options
+        ) {
+            assert.ok(data.hasOwnProperty("type"));
+            assert.ok(data.hasOwnProperty("action"));
+            assert.ok(data.hasOwnProperty("severity"));
+            assert.ok(data.hasOwnProperty("typeId"));
+            assert.ok(data.hasOwnProperty("nodeId"));
+            assert.ok(data.hasOwnProperty("payload"));
+
+            assert.string(data.type);
+            assert.string(data.action);
+            assert.string(data.serverity);
+            assert.string(data.typeId);
+            if (data.nodeId !== null){
+                assert.string(data.nodeId);}
+            assert.object(data.payload);
+
+            data.version = '1.0';
+            data.createdAt = new Date();
+
+            return this.messenger.publish(name, routingKey, data, options);
+        };
+
+        MessengerService.prototype.publishInternalEvents  = function(
+            name, routingKey, data, options
+        ) {
+            return this.messenger.publish(name, routingKey, data, options);
+        };
+
+        MessengerService.prototype.subscribe  = function(name, routingKey, callback, type) {
+            return this.messenger.subscribe(name, routingKey, callback, type);
+        };
+
+        MessengerService.prototype.request = function(name, routingKey, data, type, timeout) {
+            return this.messenger.request(name, routingKey, data, type, timeout);
+        };
+
+        MessengerService.prototype.safeSubscriptionDispose = function (context) {
+            return this.messenger.safeSubscriptionDispose(context);
+        };
+
+        MessengerService.prototype.subscribeCallback = function(context, options) {
+            return this.messenger.subscribeCallback(context, options);
+        };
+
+        MessengerService.prototype.subscribeTimeout = function(
+            context, data, headers, deliveryInfo
+        )  {
+            return this.messenger.subscribeTimeout(context, data, headers, deliveryInfo);
+        };
+
+        return new MessengerService();
 }
+

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -21,17 +21,20 @@ describe("Event protocol subscribers", function () {
         testMessage = new Message({},{},{});
         sinon.stub(testMessage);
         sinon.stub(messenger, 'request');
-        sinon.stub(messenger, 'publish');
+        sinon.stub(messenger, 'publishExternalEvents');
+        sinon.stub(messenger, 'publishInternalEvents');
     });
 
     beforeEach(function() {
         messenger.request.reset();
-        messenger.publish.reset();
+        messenger.publishInternalEvents.reset();
+        messenger.publishExternalEvents.reset();
     });
 
     after(function() {
         messenger.request.restore();
-        messenger.publish.restore();
+        messenger.publishInternalEvents.restore();
+        messenger.publishExternalEvents.restore();
     });
 
     helper.after();
@@ -46,7 +49,7 @@ describe("Event protocol subscribers", function () {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.subscribeTftpSuccess(nodeId, function (_data) {
                 expect(_data).to.equal(data);
                 return data;
@@ -67,7 +70,7 @@ describe("Event protocol subscribers", function () {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.subscribeTftpFailure(nodeId, function (_data) {
                 expect(_data).to.equal(data);
                 return data;
@@ -88,7 +91,7 @@ describe("Event protocol subscribers", function () {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.subscribeHttpResponse(nodeId, function (_data) {
                 expect(_data).to.equal(data);
                 return data;
@@ -109,7 +112,7 @@ describe("Event protocol subscribers", function () {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.subscribeDhcpBoundLease(nodeId, function (_data) {
                 expect(_data).to.equal(data);
                 return data;
@@ -136,7 +139,7 @@ describe("Event protocol subscribers", function () {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
 
             return events.subscribeTaskFinished(domain, function (_data) {
                 expect(_data).to.deep.equal(data);
@@ -166,7 +169,7 @@ describe("Event protocol subscribers", function () {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
 
             return events.subscribeNodeNotification(nodeId, function (_data) {
                 expect(_data).to.deep.equal(data);
@@ -176,7 +179,7 @@ describe("Event protocol subscribers", function () {
                     nodeId,
                     data
                 );
-                expect(messenger.publish).to.have.been.calledWith(
+                expect(messenger.publishInternalEvents).to.have.been.calledWith(
                     'on.events',
                     'notification.' + nodeId,
                     data
@@ -190,7 +193,7 @@ describe("Event protocol subscribers", function () {
                 callback(testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
 
             return events.subscribeNodeNotification(nodeId, function () {
             }).then(function (subscription) {
@@ -198,7 +201,7 @@ describe("Event protocol subscribers", function () {
                 events.publishNodeNotification(
                     nodeId
                 );
-                expect(messenger.publish).to.have.been.calledWith(
+                expect(messenger.publishInternalEvents).to.have.been.calledWith(
                     'on.events',
                     'notification.' + nodeId,
                     ''
@@ -214,7 +217,7 @@ describe("Event protocol subscribers", function () {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
 
             return events.subscribeBroadcastNotification(function (_data) {
                 expect(_data).to.deep.equal(data);
@@ -223,7 +226,7 @@ describe("Event protocol subscribers", function () {
                 events.publishBroadcastNotification(
                     data
                 );
-                expect(messenger.publish).to.have.been.calledWith(
+                expect(messenger.publishInternalEvents).to.have.been.calledWith(
                     'on.events',
                     'notification',
                     data
@@ -231,18 +234,19 @@ describe("Event protocol subscribers", function () {
             });
         });
 
-        it("should publish and subscribe to BroadcastNotification messages without data", function(){
+        it("should publish and subscribe to BroadcastNotification messages without data",
+           function(){
             messenger.subscribe = sinon.spy(function(a,b,callback) {
                 callback(testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
 
             return events.subscribeBroadcastNotification(function () {
             }).then(function (subscription) {
                 expect(subscription).to.be.ok;
                 events.publishBroadcastNotification();
-                expect(messenger.publish).to.have.been.calledWith(
+                expect(messenger.publishInternalEvents).to.have.been.calledWith(
                     'on.events',
                     'notification',
                     ''
@@ -262,7 +266,7 @@ describe("Event protocol subscribers", function () {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.subscribeGraphStarted(graphId, function (_data) {
                 expect(_data).to.equal(data);
                 return data;
@@ -287,7 +291,7 @@ describe("Event protocol subscribers", function () {
                 callback({status:status},testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.subscribeGraphFinished(graphId, function (_data) {
                 expect(_data).to.equal(status);
                 return status;
@@ -309,7 +313,7 @@ describe("Event protocol subscribers", function () {
                 callback({sku:skuId},testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.subscribeSkuAssigned(nodeId, function (sku) {
                 expect(sku).to.equal(skuId);
                 return skuId;
@@ -330,14 +334,14 @@ describe("Event protocol subscribers", function () {
         });
        it("should publish an unhandled error", function () {
             var testError = Error('unhandled');
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.publishUnhandledError(function(err) {
                 expect(err).to.equal(testError);
             });
         });
        it("should publish a blocked event", function () {
             var testError = Error('blockedEvent');
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.publishBlockedEventLoop(function(err) {
                 expect(err).to.equal(testError);
             });
@@ -361,18 +365,20 @@ describe("Event protocol subscribers", function () {
         });
 
         it('should publish without additional data', function(){
-            messenger.publish.resolves();
+            messenger.publishExternalEvents.resolves();
 
             return events.publishNodeEvent(testNode, testAction)
             .then(function(){
-                expect(messenger.publish).to.have.been.calledWith(
+                expect(messenger.publishExternalEvents).to.have.been.calledWith(
                     'on.events',
                     'event.node',
                     {
                         type: 'node',
                         action: testAction,
                         nodeId: testNodeId,
-                        nodeType: testType
+                        nodeType: testType,
+                        typeId: testNodeId,
+                        payload: null
                     });
             });
         });
@@ -383,11 +389,11 @@ describe("Event protocol subscribers", function () {
                     "for": "publishing"
                 };
 
-            messenger.publish.resolves();
+            messenger.publishExternalEvents.resolves();
 
             return events.publishNodeEvent(testNode, testAction, testData)
             .then(function(){
-                expect(messenger.publish).to.have.been.calledWith(
+                expect(messenger.publishExternalEvents).to.have.been.calledWith(
                     'on.events',
                     'event.node',
                     {
@@ -395,7 +401,8 @@ describe("Event protocol subscribers", function () {
                         action: testAction,
                         nodeId: testNodeId,
                         nodeType: testType,
-                        data: testData
+                        typeId: testNodeId,
+                        payload: testData
                     });
             });
         });
@@ -407,16 +414,18 @@ describe("Event protocol subscribers", function () {
             var oldNode = {id: 'aaa', type: 'compute', sku: ''};
             var newNode = {id: 'aaa', type: 'compute', sku: 'bbb'};
 
-            messenger.publish.resolves();
+            messenger.publishExternalEvents.resolves();
 
             return events.publishNodeAttrEvent(oldNode, newNode, 'sku')
             .then(function () {
-                expect(messenger.publish).to.have.been
+                expect(messenger.publishExternalEvents).to.have.been
                 .calledWith('on.events', 'event.node',
                     { type: 'node',
                       action: 'sku.assigned',
                       nodeId : 'aaa',
-                      nodeType: 'compute' });
+                      nodeType: 'compute',
+                      typeId: 'aaa',
+                      payload: null});
             });
         });
 
@@ -424,16 +433,18 @@ describe("Event protocol subscribers", function () {
             var oldNode = {id: 'aaa', type: 'compute', sku: 'bbb'};
             var newNode = {id: 'aaa', type: 'compute', sku: ''};
 
-            messenger.publish.resolves();
+            messenger.publishExternalEvents.resolves();
 
             return events.publishNodeAttrEvent(oldNode, newNode, 'sku')
             .then(function () {
-                expect(messenger.publish).to.have.been
+                expect(messenger.publishExternalEvents).to.have.been
                 .calledWith('on.events', 'event.node',
                     { type: 'node',
                       action: 'sku.unassigned',
                       nodeId : 'aaa',
-                      nodeType: 'compute' });
+                      nodeType: 'compute',
+                      typeId: 'aaa',
+                      payload: null});
             });
         });
 
@@ -441,16 +452,18 @@ describe("Event protocol subscribers", function () {
             var oldNode = {id: 'aaa', type: 'compute', sku: 'bbb'};
             var newNode = {id: 'aaa', type: 'compute', sku: 'ccc'};
 
-            messenger.publish.resolves();
+            messenger.publishExternalEvents.resolves();
 
             return events.publishNodeAttrEvent(oldNode, newNode, 'sku')
             .then(function () {
-                expect(messenger.publish).to.have.been
+                expect(messenger.publishExternalEvents).to.have.been
                 .calledWith('on.events', 'event.node',
                     { type: 'node',
                       action: 'sku.updated',
                       nodeId : 'aaa',
-                      nodeType: 'compute' });
+                      nodeType: 'compute',
+                      typeId: 'aaa',
+                      payload: null});
             });
         });
 
@@ -458,11 +471,11 @@ describe("Event protocol subscribers", function () {
             var oldNode = {id: 'aaa', type: 'compute', sku: ''};
             var newNode = {id: 'aaa', type: 'compute', sku: ''};
 
-            messenger.publish.resolves();
+            messenger.publishExternalEvents.resolves();
 
             return events.publishNodeAttrEvent(oldNode, newNode, 'sku')
             .then(function () {
-                expect(messenger.publish).to.have.not.been.called;
+                expect(messenger.publishExternalEvents).to.have.not.been.called;
             });
         });
 
@@ -470,15 +483,15 @@ describe("Event protocol subscribers", function () {
             var oldNode = {id: 'aaa', type: 'compute', sku: ''};
             var newNode = {id: 'bbb', type: 'compute', sku: 'abc'};
 
-            messenger.publish.resolves();
+            messenger.publishExternalEvents.resolves();
 
             return events.publishNodeAttrEvent(oldNode, newNode, 'sku')
             .then(function () {
-                expect(messenger.publish).to.have.not.been.called;
+                expect(messenger.publishExternalEvents).to.have.not.been.called;
             });
         });
     });
-    
+
     describe("publish graph progress event", function () {
         it("should publish graph progress event", function () {
             var uuid = helper.injector.get('uuid');
@@ -492,15 +505,16 @@ describe("Event protocol subscribers", function () {
                     taskId: "anything"
                 }
             };
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
             return events.publishProgressEvent(data)
             .then(function () {
-                expect(messenger.publish).to.be.calledWith(
+                expect(messenger.publishInternalEvents).to.be.calledWith(
                     'on.events',
-                    'graph.progress' + '.' + data.graphId, 
+                    'graph.progress' + '.' + data.graphId,
                     data);
             });
         });
 
     });
 });
+

--- a/spec/lib/protocol/task-graph-runner-spec.js
+++ b/spec/lib/protocol/task-graph-runner-spec.js
@@ -33,12 +33,12 @@ describe("TaskGraph Runner protocol functions", function () {
     describe("runTaskGraph", function() {
         it("should publish to runTaskGraph", function() {
             var graphId = uuid.v4();
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
 
             return taskgraphrunner.runTaskGraph(graphId, 'default')
             .then(function() {
-                expect(messenger.publish).to.have.been.calledOnce;
-                expect(messenger.publish).to.have.been.calledWith(
+                expect(messenger.publishInternalEvents).to.have.been.calledOnce;
+                expect(messenger.publishInternalEvents).to.have.been.calledWith(
                     Constants.Protocol.Exchanges.TaskGraphRunner.Name,
                     'methods.runTaskGraph.default',
                     { graphId: graphId }

--- a/spec/lib/protocol/task-spec.js
+++ b/spec/lib/protocol/task-spec.js
@@ -38,7 +38,8 @@ describe("Task protocol functions", function() {
                 callback(args,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishExternalEvents.resolves();
+            messenger.publishInternalEvents.resolves();
             messenger.request.resolves(args);
             return task.subscribeRun(taskId, function(_data) {
                 expect(_data).to.be.ok;
@@ -63,7 +64,8 @@ describe("Task protocol functions", function() {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             task.subscribeCancel(function(_data) {
                 expect(_data).to.be.an.instanceof(Error);
                 expect(_data).to.have.property('message').that.equals(data.errMessage);
@@ -84,7 +86,8 @@ describe("Task protocol functions", function() {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeCancel(function(_data) {
                 expect(_data).to.be.an.instanceof(Errors.TaskTimeoutError);
                 expect(_data).to.have.property('message').that.equals(data.errMessage);
@@ -264,7 +267,8 @@ describe("Task protocol functions", function() {
                 callback({value:testData},testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             task.subscribeRespondCommands(taskId, function(data) {
                 expect(data).to.deep.equal(testData);
             }).then(function(subscription) {
@@ -410,7 +414,8 @@ describe("Task protocol functions", function() {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeHttpResponse(id, function(_data) {
                 expect(_data).to.deep.equal(data);
             })
@@ -430,7 +435,8 @@ describe("Task protocol functions", function() {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeTftpSuccess(id, function(_data) {
                 expect(_data).to.deep.equal(data);
             })
@@ -450,7 +456,8 @@ describe("Task protocol functions", function() {
                 callback;
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeDhcpBoundLease(id, function(_data) {
                 expect(_data).to.deep.equal(data);
             })
@@ -469,7 +476,8 @@ describe("Task protocol functions", function() {
                 callback({value:otherId},testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeHttpResponse(otherId, function () {
                 return;
             }).then(function (sub) {
@@ -498,7 +506,8 @@ describe("Task protocol functions", function() {
                 callback({value:testData},testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeRunIpmiCommand(testUuid, testCommand, function(_data) {
                 expect(_data).to.deep.equal(testData);
             }).then(function(subscription) {
@@ -519,7 +528,8 @@ describe("Task protocol functions", function() {
                 callback({value:testData},testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeIpmiCommandResult(testUuid, testCommand, function(_data) {
                 expect(_data).to.deep.equal(testData);
             }).then(function(subscription) {
@@ -539,7 +549,8 @@ describe("Task protocol functions", function() {
                 callback({value:testData},testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeRunSnmpCommand(testUuid, function(_data) {
                 expect(_data).to.deep.equal(testData);
             }).then(function(subscription) {
@@ -559,7 +570,8 @@ describe("Task protocol functions", function() {
                 callback({value:testData},testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeSnmpCommandResult(testUuid, function(_data) {
                 expect(_data).to.deep.equal(testData);
             }).then(function(subscription) {
@@ -579,7 +591,8 @@ describe("Task protocol functions", function() {
                 callback({value:testData},{deliveryInfo:{routingKey:'test.key'}});
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeMetricResult(testUuid, 'testmetric', function(_data) {
                 expect(_data).to.deep.equal(testData);
             }).then(function(subscription) {
@@ -596,7 +609,8 @@ describe("Task protocol functions", function() {
                 uuid = helper.injector.get('uuid'),
                 testUuid = uuid.v4(),
                 pollerName = 'sdr';
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.publishPollerAlert(testUuid, pollerName, data);
         });
     });
@@ -661,7 +675,8 @@ describe("Task protocol functions", function() {
                 callback({value:testData},testMessage);
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeAnsibleCommand(testUuid, function(_data) {
                 expect(_data).to.deep.equal(testData);
             }).then(function(subscription) {
@@ -682,7 +697,8 @@ describe("Task protocol functions", function() {
                 callback();
                 return Promise.resolve(testSubscription);
             });
-            messenger.publish.resolves();
+            messenger.publishInternalEvents.resolves();
+            messenger.publishExternalEvents.resolves();
             return task.subscribeTrigger(testUuid, triggerType, triggerGroup, function() {
                 return;
             }).then(function(subscription) {

--- a/spec/lib/protocol/waterline-spec.js
+++ b/spec/lib/protocol/waterline-spec.js
@@ -23,17 +23,17 @@ describe('Protocol.Waterline', function() {
     helper.after();
 
     it('should publish a created event', function() {
-        messenger.publish.resolves();
+        messenger.publishInternalEvents.resolves();
         return waterlineProtocol.publishRecord(collection, 'created', { id: 1 });
     });
 
     it('should publish an updated event', function() {
-        messenger.publish.resolves();
+        messenger.publishInternalEvents.resolves();
         return waterlineProtocol.publishRecord(collection, 'updated', { id: 1 });
     });
 
     it('should publish a destroyed event', function() {     
-        messenger.publish.resolves();
+        messenger.publishInternalEvents.resolves();
         return waterlineProtocol.publishRecord(collection, 'destroyed', { id: 1 });
     });
 });

--- a/spec/lib/services/heartbeat-spec.js
+++ b/spec/lib/services/heartbeat-spec.js
@@ -32,7 +32,7 @@ describe('Heartbeat', function () {
         stop: sandbox.stub().returns(
             Promise.resolve()
         ),
-        publish: sandbox.stub().returns(
+        publishExternalEvents: sandbox.stub().returns(
             Promise.resolve()
         )
     };
@@ -40,12 +40,12 @@ describe('Heartbeat', function () {
         lookupServiceAsync: sandbox.stub(),
         lookupAsync: sandbox.stub()
     };
-    
+
     helper.before(function() {
-        return [ 
+        return [
             helper.di.simpleWrapper(messenger, 'Services.Messenger'),
             helper.di.simpleWrapper(rx, 'Rx')
-        ]
+        ];
     });
 
     before(function () {
@@ -53,7 +53,7 @@ describe('Heartbeat', function () {
         constants = helper.injector.get('Constants');
         sandbox.stub(heartbeat, 'requireDns').returns(dns);
     });
-    
+
     beforeEach(function() {
         sandbox.reset();
     });
@@ -71,30 +71,30 @@ describe('Heartbeat', function () {
                 expect(heartbeat.running).to.be.true;
             });
         });
-        
+
         it('should stop', function() {
             return heartbeat.start().then(function() {
                 return heartbeat.stop().then(function() {
                     expect(heartbeat.subscription.dispose).to.have.been.calledOnce;
                     expect(heartbeat.running).to.be.false;
-                })
+                });
             });
         });
-        
+
         it('should send heartbeat message', function() {
             return heartbeat.sendHeartbeat()
             .then(function() {
-                expect(messenger.publish).to.be.calledOnce;
+                expect(messenger.publishExternalEvents).to.be.calledOnce;
             });
         });
-        
+
         it('should resolve hostname', function() {
             dns.lookupServiceAsync.resolves(undefined);
             return heartbeat.getFqdn().then(function(hostname) {
                 expect(hostname).to.equal(constants.Host);
             });
         });
-        
+
         it('should resolve FQDN', function() {
             var testFqdn = constants.Host + '.example.com';
             dns.lookupServiceAsync.resolves([testFqdn]);

--- a/spec/lib/services/messenger-spec.js
+++ b/spec/lib/services/messenger-spec.js
@@ -103,7 +103,7 @@ describe('Messenger', function () {
     
     describe('publish/subscribe', function () {
         it('should resolve if the published data is an object', function () {
-            return this.subject.publish(
+            return this.subject.publishInternalEvents(
                 Constants.Protocol.Exchanges.Test.Name,
                 'test',
                 { hello: 'world' }
@@ -111,7 +111,7 @@ describe('Messenger', function () {
         });
 
         it('should reject if the published data is invalid', function () {
-            return this.subject.publish(
+            return this.subject.publishInternalEvents(
                 Constants.Protocol.Exchanges.Test.Name,
                 'test',
                 new IpAddress({ value: 'invalid' })
@@ -119,7 +119,7 @@ describe('Messenger', function () {
         });
 
         it('should resolve if the published data is valid', function () {
-            return this.subject.publish(
+            return this.subject.publishInternalEvents(
                 Constants.Protocol.Exchanges.Test.Name,
                 'test',
                 new IpAddress({ value: '10.1.1.1' })
@@ -138,7 +138,7 @@ describe('Messenger', function () {
                 }
             ).then(function (sub) {
                 expect(sub).to.be.ok;
-                return self.subject.publish(
+                return self.subject.publishInternalEvents(
                     Constants.Protocol.Exchanges.Test.Name,
                     'test',
                     { hello: 'world' }
@@ -156,8 +156,8 @@ describe('Messenger', function () {
                         { hello: 'world' }
                     );
                 }
-            ).then(function (sub) {
-                return self.subject.publish(
+            ).then(function () {
+                return self.subject.publishInternalEvents(
                     Constants.Protocol.Exchanges.Test.Name,
                     'test',
                     { hello: 'world' }
@@ -172,7 +172,7 @@ describe('Messenger', function () {
                 function (){}
             ).should.be.rejectedWith(Error);
         });
-        
+
         it('should throw if subscribed with an invalid type', function () {
             testData = { hello: 'world' };
             var self = this;
@@ -182,21 +182,21 @@ describe('Messenger', function () {
                 function(){},
                 function(){}
             ).then(function() {
-                expect(self.subject.receive.queue).to.throw(Error);
+                expect(self.subject.messenger.receive.queue).to.throw(Error);
             });
         });
 
         it('should reject if published to an invalid exchange', function () {
-            return this.subject.publish(
+            return this.subject.publishInternalEvents(
                 'invalid',
                 'invalid',
                 { hello: 'invalid' }
             ).should.be.rejectedWith(Error);
         });
-        
+
         it('should reject if no transmit connection established', function () {
-            this.subject.transmit = undefined;
-            return this.subject.publish(
+            this.subject.messenger.transmit = undefined;
+            return this.subject.publishInternalEvents(
                 Constants.Protocol.Exchanges.Test.Name,
                 'test',
                 { hello: 'world' }


### PR DESCRIPTION
This is the first version, what it does:
1.  Wrap the messenger.js in lib/common
2.  Add two different methods for publishing the internal and external events 

What needs to be donw:
1. Add comments to the methods
2. Removing the publish mehtod and replace it with  publish internal and external methods respectively.
3. Redefine publish external events to complete the discussed format
 @iceiilin @pengz1 @anhou @yyscamper  
 
The second version is done:
what it does:
1.  Remove the publish method on lib/service/messenger.js
2. Change the publish method to publishExternal/publishInternal in all repo. 
Code change as item 2 is done on other repos too, but doesn't send out for review now