### PR TITLE
nonterminal, handled tasks no longer prevent graph from finishing

### DIFF
--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -613,13 +613,11 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
             reachable: true
         };
 
-        return waterline.taskdependencies.findOne(query)
-        .then(function(result) {
-            if (_.isEmpty(result)) {
-                data.done = true;
-            } else {
-                data.done = false;
-            }
+        return waterline.taskdependencies.find(query)
+        .then(function(results) {
+            data.done = _.every(results, function(task) {
+                return !_.contains(task.terminalOnStates, task.state);
+            });
             return data;
         });
     };


### PR DESCRIPTION
solves https://rackhd.atlassian.net/browse/RAC-1938

changed the mongo store checkGraphSucceeded method to succeed on graphs where the only task dependencies we find with waterline.taskdependencies.find are non-terminal.
@rolandpoulter @pscharla 