### PR TITLE
Refactor publish external events to add several fields

### DIFF
--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -11,8 +11,7 @@ eventsProtocolFactory.$inject = [
     'Services.Messenger',
     'Promise',
     'validator',
-    'Assert',
-    'Errors'
+    'Assert'
 ];
 
 function eventsProtocolFactory (
@@ -21,8 +20,7 @@ function eventsProtocolFactory (
     messenger,
     Promise,
     validator,
-    assert,
-    Error
+    assert
 ) {
     function EventsProtocol () {
     }
@@ -275,18 +273,29 @@ function eventsProtocolFactory (
         );
     };
 
-    EventsProtocol.prototype.publishEvent = function (data) {
+    EventsProtocol.prototype.publishExternalEvent = function (data) {
         assert.object(data);
         assert.string(data.type);
+        assert.string(data.action);
+        assert.string(data.severity);
+        assert.string(data.typeId);
+        assert.ok(data.hasOwnProperty("payload"));
+        if (data.nodeId !== null){
+            assert.string(data.nodeId);}
 
+        data.version = '1.0';
+        data.createdAt = new Date();
+
+        var routingKey = data.type + '.' + data.typeId + '.' + data.action +
+                         '.' + data.severity + '.' + data.nodeId;
         return messenger.publish(
             Constants.Protocol.Exchanges.Events.Name,
-            'event' + '.' + data.type,
+            routingKey,
             data
         );
     };
 
-    EventsProtocol.prototype.publishNodeEvent = function (node, action, data) {
+    EventsProtocol.prototype.publishNodeEvent = function (node, action, data, severity) {
         var self = this;
         assert.object(node);
         assert.string(action);
@@ -295,14 +304,14 @@ function eventsProtocolFactory (
             type: 'node',
             action: action,
             nodeId: node.id,
-            nodeType: node.type
-        };
+            nodeType: node.type,
+            typeId: node.id
+         };
 
-        if(data){
-            nodeEvent.data = data;
-        }
+         nodeEvent.payload = data || null;
+         nodeEvent.severity = severity || "information";
 
-        return self.publishEvent(nodeEvent);
+        return self.publishExternalEvent(nodeEvent);
     };
 
     EventsProtocol.prototype.publishNodeAttrEvent = function (oldNode, newNode, attr) {
@@ -342,3 +351,4 @@ function eventsProtocolFactory (
 
     return new EventsProtocol();
 }
+

--- a/lib/services/heartbeat.js
+++ b/lib/services/heartbeat.js
@@ -11,7 +11,7 @@ heartbeatServiceFactory.$inject = [
     'Assert',
     'Constants',
     'Rx',
-    'Services.Messenger',
+    'Protocol.Events',
     'Result',
     'Logger'
 ];
@@ -22,7 +22,7 @@ function heartbeatServiceFactory(
     assert,
     Constants,
     Rx,
-    messenger,
+    events,
     Result,
     Logger
 ) {
@@ -44,6 +44,13 @@ function heartbeatServiceFactory(
             versions: process.versions,
             memoryUsage: process.memoryUsage()
         };
+
+        this.data = {
+            type: "heartbeat",
+            action: "updated",
+            nodeId: null,
+            severity: "information",
+        };
     }
     
     HeartbeatService.prototype.requireDns = function() {
@@ -56,7 +63,7 @@ function heartbeatServiceFactory(
         }
         return 'NA'; // Added in: v6.1.0
     };
-        
+
     HeartbeatService.prototype.getFqdn = Promise.method(function() {
         var self = this;
         var dns = self.requireDns();
@@ -75,17 +82,17 @@ function heartbeatServiceFactory(
         }
         return Constants.Host;
     });
-    
+
     HeartbeatService.prototype.isRunning = function() {
         return this.running;
     };
-    
+
     HeartbeatService.prototype.sendHeartbeat = function() {
         var self = this;
-        return messenger.publish(
-            Constants.Protocol.Exchanges.Heartbeat.Name,
-            self.routingKey, 
-            new Result({value: self.info})
+
+        self.data.payload = self.info;
+        return events.publishExternalEvent(
+           self.data
         )
         .then(function() {
             self.lastUpdate = self.info.currentTime;
@@ -96,7 +103,6 @@ function heartbeatServiceFactory(
         var self = this;
         if(this.intervalSec > 0) { // setting interval to 0 disables heartbeat
             return self.getFqdn().then(function(fqdn) {
-                self.routingKey = fqdn + '.' + self.name;
                 self.running = true;
                 self.subscription = Rx.Observable.interval(self.intervalSec * 1000)
                 .takeWhile(self.isRunning.bind(self))
@@ -106,9 +112,10 @@ function heartbeatServiceFactory(
                         self.info.nextUpdate = new Date(
                             self.info.currentTime.valueOf() + self.intervalSec * 1000
                         );
-                        self.info.lastUpdate = self.lastUpdate
+                        self.info.lastUpdate = self.lastUpdate;
                         self.info.memoryUsage = process.memoryUsage();
                         self.info.cpuUsage = self.getCpuUsage();
+                        self.data.typeId = fqdn + ".heartbeat";
                         self.sendHeartbeat();
                     },
                     function(error) {
@@ -117,7 +124,7 @@ function heartbeatServiceFactory(
                         }
                     }
                 );
-                
+
                 return self.subscription;
             });
         }

--- a/spec/lib/services/heartbeat-spec.js
+++ b/spec/lib/services/heartbeat-spec.js
@@ -25,14 +25,8 @@ describe('Heartbeat', function () {
             })
         }
     };
-    var messenger = {
-        start: sandbox.stub().returns(
-            Promise.resolve()
-        ),
-        stop: sandbox.stub().returns(
-            Promise.resolve()
-        ),
-        publish: sandbox.stub().returns(
+    var events = {
+        publishExternalEvent: sandbox.stub().returns(
             Promise.resolve()
         )
     };
@@ -43,9 +37,9 @@ describe('Heartbeat', function () {
     
     helper.before(function() {
         return [ 
-            helper.di.simpleWrapper(messenger, 'Services.Messenger'),
+            helper.di.simpleWrapper(events, 'Protocol.Events'),
             helper.di.simpleWrapper(rx, 'Rx')
-        ]
+        ];
     });
 
     before(function () {
@@ -77,24 +71,24 @@ describe('Heartbeat', function () {
                 return heartbeat.stop().then(function() {
                     expect(heartbeat.subscription.dispose).to.have.been.calledOnce;
                     expect(heartbeat.running).to.be.false;
-                })
+                });
             });
         });
         
         it('should send heartbeat message', function() {
             return heartbeat.sendHeartbeat()
             .then(function() {
-                expect(messenger.publish).to.be.calledOnce;
+                expect(events.publishExternalEvent).to.be.calledOnce;
             });
         });
-        
+
         it('should resolve hostname', function() {
             dns.lookupServiceAsync.resolves(undefined);
             return heartbeat.getFqdn().then(function(hostname) {
                 expect(hostname).to.equal(constants.Host);
             });
         });
-        
+
         it('should resolve FQDN', function() {
             var testFqdn = constants.Host + '.example.com';
             dns.lookupServiceAsync.resolves([testFqdn]);


### PR DESCRIPTION
1. On lib.protocol, rename publishevent to publishExternalEvent
Check required field for external events in this function
2. Make changes to node event and heartbeat event, so that it conforms to the required fields for external event
@pengz1 @iceiilin @anhou @yyscamper 