### PR TITLE
modify poller alert function to be legacy

### DIFF
--- a/lib/protocol/task.js
+++ b/lib/protocol/task.js
@@ -415,7 +415,7 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
     };
 
     // NOTE: publishes onto the events exchange
-    TaskProtocol.prototype.publishPollerAlert = function (uuid, pollerName, results) {
+    TaskProtocol.prototype.publishPollerAlertLegacy = function (uuid, pollerName, results) {
         assert.uuid(uuid, 'routing key uuid suffix');
         assert.string(pollerName, 'poller name suffix');
         assert.object(results);

--- a/spec/lib/protocol/task-spec.js
+++ b/spec/lib/protocol/task-spec.js
@@ -597,7 +597,7 @@ describe("Task protocol functions", function() {
                 testUuid = uuid.v4(),
                 pollerName = 'sdr';
             messenger.publish.resolves();
-            return task.publishPollerAlert(testUuid, pollerName, data);
+            return task.publishPollerAlertLegacy(testUuid, pollerName, data);
         });
     });
 


### PR DESCRIPTION
modify poller alert function to xxxLegacy, which will be used by on-tasks to be compatible with the old format. (The new event will use eventsProtocol.publishExternalEvent in on-core)

Jenkins: depend on https://github.com/RackHD/on-tasks/pull/391 https://github.com/RackHD/RackHD/pull/587