### PR TITLE
Change check for multiple amqp URIs from an array to an object.

### DIFF
--- a/lib/common/messenger.js
+++ b/lib/common/messenger.js
@@ -92,7 +92,7 @@ function messengerFactory(
             options = {
                 url: uri
             };
-        } else if (Array.isArray(uri)) {
+        } else if (typeof uri === 'object') {
             options = uri;
         } else {
             console.log('Setting AMQP URL to localhost');


### PR DESCRIPTION
Multiple AMPQ servers are passed to amqp library as an array inside an object.
This changes the check of the uri parameter as an object instead of an array.