### PR TITLE
[skip ci]add uniform sources list for docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM nodesource/wheezy:4.4.6
 
+ADD https://raw.githubusercontent.com/RackHD/on-build-config/master/build-release-tools/docker_sources.list /etc/apt/sources.list
 COPY . /RackHD/on-core/
 
 RUN cd /RackHD/on-core \


### PR DESCRIPTION
https://rackhd.atlassian.net/browse/RAC-4215

### Background
The root base image of rackhd on-xxx docker images is ```nodesource/wheezy```
However, the source list of this base image can not satisfy our needs.
This sources list was used to be added in jenkins docker build steps.
As well as in https://github.com/RackHD/on-taskgraph/blob/master/Dockerfile for fixing some issue.

### Details
now we decide to add sources list in on-core(the root image of all on-xxx) for  unification.
Both https://github.com/RackHD/on-build-config/pull/80 and https://github.com/RackHD/on-taskgraph/pull/211 will remove the sources list add steps.

@panpan0000 

PR merge order:
This PR first, then after dockerhub autobuild success,
https://github.com/RackHD/on-taskgraph/pull/211 should be merged.
then the next day
https://github.com/RackHD/on-build-config/pull/80 should be merged to support the daily build.
