### PR TITLE
add default timeout value for cancelTaskGraph

### DIFF
--- a/lib/protocol/task-graph-runner.js
+++ b/lib/protocol/task-graph-runner.js
@@ -252,6 +252,7 @@ function taskGraphRunnerProtocolFactory (
         assert.uuid(graphId);
 
         var filter = {graphId: graphId};
+        timeout = typeof timeout !== 'undefined' ? timeout : 5000;
         return messenger.request(
             Constants.Protocol.Exchanges.TaskGraphRunner.Name,
             'methods.cancelTaskGraph',


### PR DESCRIPTION
It is found that in continuous functional test, "test_node_workflows_del_active" in CIT fails more than once per day. The reason is that RPC request of canceling taskgraph from on-http takes more than one second (usually 2s, from the vagrant log) to complete when on-taskgraph is busy evaluating other tasks during that period of time. In RackHD, the default timeout value for an RPC request is 1s. This PR changes the cancelTaskGraph request to 5s timeout