### PR TITLE
Clean up part for waitOn.anyOf

### DIFF
--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -643,22 +643,39 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
         assert.uuid(data.taskId, 'data.taskId');
         assert.string(data.state, 'data.state');
 
-        var query = {
+        var queryDependency = {
             graphId: data.graphId,
             reachable: true
         };
-        query['dependencies.' + data.taskId] = {
+        queryDependency['dependencies.' + data.taskId] = {
             $in: [data.state, Constants.Task.States.Finished]
         };
-        var update = {
+        
+        var updateDependency = {
             $unset: {}
         };
-        update.$unset['dependencies.' + data.taskId] = '';
+        updateDependency.$unset['dependencies.' + data.taskId] = '';
+
+        var queryAnyOf = {
+            graphId: data.graphId,
+            reachable: true
+        };
+        queryAnyOf['dependencies.anyOf.' + data.taskId] = {
+            $in: [data.state, Constants.Task.States.Finished]
+        };
+        var updateAnyOf = {
+            $unset: {}
+        };
+        updateAnyOf.$unset["dependencies.anyOf"] = "";
+
         var options = {
             multi: true
         };
-
-        return waterline.taskdependencies.updateMongo(query, update, options);
+        
+        return Promise.all([
+            waterline.taskdependencies.updateMongo(queryDependency, updateDependency, options),
+            waterline.taskdependencies.updateMongo(queryAnyOf, updateAnyOf, options)
+        ]);
     };
 
     /**
@@ -681,21 +698,78 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
 
         var query = {
             graphId: data.graphId,
-            reachable: true
+            reachable: true,
+            $or: [{},{}]
         };
-        query['dependencies.' + data.taskId] = {
-            $in: _.difference(Constants.Task.FinishedStates, [data.state])
-        };
-        var update = {
-            $set: {
-                reachable: false
-            }
-        };
+
         var options = {
             multi: true
         };
 
-        return waterline.taskdependencies.updateMongo(query, update, options);
+        query.$or[0]['dependencies.'+data.taskId] = {
+            $in: _.difference(Constants.Task.FinishedStates, [data.state])
+        };
+        query.$or[1]['dependencies.anyOf'+data.taskId] = {
+            $in: _.difference(Constants.Task.FinishedStates, [data.state])
+        };
+
+        return waterline.taskdependencies.find(query).then(function(res){
+            var updateRemove = {
+                $unset:{}
+            };
+            updateRemove.$unset['dependencies.anyOf.'+data.taskId] = "";
+            var queryRemove = {
+                graphId: data.graphId,
+                reachable: true,
+                // List of task Ids that need to remove dependent.anyOf.<data.taskId>
+                $or:[]
+            };
+
+            // Mongo update, mark the downstream task unreachable
+            var setUnreachable = {
+                $set: {
+                    reachable: false
+                }
+            };
+            var querySetUnreachable = {
+                graphId: data.graphId,
+                reachable: true,
+                // List of task Ids that need to mark as unrechable
+                $or: []
+            };
+            
+            _.forEach(res, function(itrTask){
+                var taskIns = {
+                    taskId: ""
+                };
+                if (! _.isEmpty(itrTask.dependencies[data.taskId])) {
+                    taskIns.taskId = itrTask.taskId;
+                    querySetUnreachable.$or.push(taskIns);
+                }
+                else {
+                    taskIns.taskId = itrTask.taskId;
+                    var anyDepSize = Object.keys(itrTask.dependencies.anyOf).length;
+                    if (anyDepSize > 1) {
+                        queryRemove.$or.push(taskIns);
+                    }
+                    else {
+                        querySetUnreachable.$or.push(taskIns); 
+                    }
+                }
+            });
+            
+            var retPromise = [];
+            if (queryRemove.$or.length > 0) {
+                retPromise.push(waterline.taskdependencies
+                .updateMongo(queryRemove, updateRemove, options));
+            }
+            if (querySetUnreachable.$or.length > 0) {
+                retPromise.push(waterline.taskdependencies
+                .updateMongo(querySetUnreachable, setUnreachable, options));
+            }
+            
+            return Promise.all(retPromise);
+        });
     };
 
     /**

--- a/spec/lib/workflow/stores/mongo-spec.js
+++ b/spec/lib/workflow/stores/mongo-spec.js
@@ -635,63 +635,12 @@ describe('Task Graph mongo store interface', function () {
        
         makeDatabase(waterlineUnderAnyOf);
         
-<<<<<<< HEAD
         var data = {
             state: 'succeeded',
             taskId: uuid.v4(),
             graphId: uuid.v4()
         };
 
-        return mongo.updateDependentTasks(data)
-        .then(function() {
-            var query = {
-                graphId: data.graphId,
-                reachable: true
-            };
-
-            query['dependencies.anyOf.' + data.taskId] = {
-                $in: [data.state, Constants.Task.States.Finished]
-            };
-
-            var updateAny = {
-                $unset:{}
-            };
-            updateAny.$unset['dependencies.anyOf'] = "";
-
-            expect(waterline.taskdependencies.updateMongo).to.have.been.calledTwice;
-            expect(waterline.taskdependencies.updateMongo).to.have.been.calledWith(
-                query, updateAny, {multi: true});
-        });
-    });
-
-    var setupWaterlineDependency = function(dependentTask) {
-         var waterlineWithDep = {
-            taskdependencies:{
-                find: sinon.stub().resolves([dependentTask]),
-                updateMongo: sinon.stub().resolves()
-            }
-        };
-
-        makeDatabase(waterlineWithDep); 
-    };
-
-    it('updates unreachable tasks under dependencies', function() {
-=======
->>>>>>> bffeef7df9f1a8c6c62f85154e7f81fdb238985d
-        var data = {
-            state: 'succeeded',
-            taskId: uuid.v4(),
-            graphId: uuid.v4()
-        };       
-        
-        var dependentTask = {
-            taskId: uuid.v4(),
-            dependencies:{}
-        };
-        dependentTask.dependencies[data.taskId] = 'failed';
-
-<<<<<<< HEAD
-=======
         return mongo.updateDependentTasks(data)
         .then(function() {
             var query = {
@@ -738,7 +687,6 @@ describe('Task Graph mongo store interface', function () {
         };
         dependentTask.dependencies[data.taskId] = 'failed';
 
->>>>>>> bffeef7df9f1a8c6c62f85154e7f81fdb238985d
         setupWaterlineDependency(dependentTask);
  
         var queryUpdate = {
@@ -780,27 +728,8 @@ describe('Task Graph mongo store interface', function () {
             $or:[{},{}]
         };
         queryFind.$or[0]['dependencies.' + data.taskId] = {
-<<<<<<< HEAD
-=======
             $in: _.difference(Constants.Task.FinishedStates, [data.state])
         };
-        queryFind.$or[1]['dependencies.anyOf' + data.taskId] = {
->>>>>>> bffeef7df9f1a8c6c62f85154e7f81fdb238985d
-            $in: _.difference(Constants.Task.FinishedStates, [data.state])
-        };       
-       
-        setupWaterlineDependency(dependentTask); 
-        
-        var updateQuery = {
-            $or: [{taskId: dependentTask.taskId}],
-            graphId: data.graphId,
-            reachable: true
-        };        
-
-        var dbUpdate = {
-            $unset: {}
-        };
-<<<<<<< HEAD
         queryFind.$or[1]['dependencies.anyOf' + data.taskId] = {
             $in: _.difference(Constants.Task.FinishedStates, [data.state])
         };       
@@ -816,8 +745,6 @@ describe('Task Graph mongo store interface', function () {
         var dbUpdate = {
             $unset: {}
         };
-=======
->>>>>>> bffeef7df9f1a8c6c62f85154e7f81fdb238985d
         dbUpdate.$unset["dependencies.anyOf." + data.taskId] = "";
 
         return mongo.updateUnreachableTasks(data)


### PR DESCRIPTION
This is a substitution of PR https://github.com/RackHD/on-core/pull/253

@RackHD/corecommitters
@pscharla
@VulpesArtificem

This is part of the change regarding adding waitOn.either feature to workflow engine.The Original task at following location:
https://github.com/RackHD/on-tasks/pull/405

Please Check the on-tasks PR regarding the request.

Please note that: Need to merge both PRs to enable this feature

jenkins: depends on https://github.com/RackHD/on-tasks/pull/405
