### PR TITLE
Remove legacy events

### DIFF
--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -326,10 +326,7 @@ function eventsProtocolFactory (
             data: data || {}
         };
 
-        return self.publishExternalEvent(heartbeatEvent)
-            .then(function () {
-                return self.publishHeartbeatEventLegacy(eventTypeId, data);
-            });
+        return self.publishExternalEvent(heartbeatEvent);
     };
 
     EventsProtocol.prototype.publishGraphEvent = function (graphId, action, nodeId, data){
@@ -365,10 +362,7 @@ function eventsProtocolFactory (
 
         nodeEvent.data.nodeType = node.type;
 
-        return self.publishExternalEvent(nodeEvent)
-            .then(function () {
-                return self.publishNodeEventLegacy(node, action, data);
-            });
+        return self.publishExternalEvent(nodeEvent);
     };
 
     EventsProtocol.prototype.publishNodeAttrEvent = function (oldNode, newNode, attr) {
@@ -401,48 +395,6 @@ function eventsProtocolFactory (
         assert.string(graphId, 'graphId');
 
         return self.publishGraphEvent(graphId, 'progress.updated', data.nodeId, data);
-    };
-
-    /*
-     * TODO: It's for legacy external event format backward compatibility,
-     * it could be deprecated when major version bump
-     */
-    EventsProtocol.prototype.publishHeartbeatEventLegacy = function (eventTypeId, data) {
-        assert.string(eventTypeId, 'eventTypeId');
-        assert.object(data, 'data');
-        var legacyRoutingKey = eventTypeId;
-
-        return messenger.publish(
-            Constants.Protocol.Exchanges.Heartbeat.Name,
-            legacyRoutingKey,
-            new Result({value: data})
-            );
-    };
-
-    /*
-     * TODO: It's for legacy external event format backward compatibility,
-     * it could be deprecated when major version bump
-     */
-    EventsProtocol.prototype.publishNodeEventLegacy = function (node, action, data) {
-        assert.object(node, 'node');
-        assert.string(action, 'action');
-
-        var legacyNodeEvent = {
-            type: 'node',
-            action: action,
-            nodeId: node.id,
-            nodeType: node.type
-        };
-
-        if(data){
-            legacyNodeEvent.data = data;
-        }
-
-        return messenger.publish(
-                Constants.Protocol.Exchanges.Events.Name,
-                'event.' + legacyNodeEvent.type,
-                legacyNodeEvent 
-                );
     };
 
     return new EventsProtocol();

--- a/lib/protocol/task.js
+++ b/lib/protocol/task.js
@@ -414,20 +414,6 @@ function taskProtocolFactory (Promise, assert, Constants, Errors, messenger, _, 
         );
     };
 
-    // NOTE: publishes onto the events exchange
-    TaskProtocol.prototype.publishPollerAlertLegacy = function (uuid, pollerName, results) {
-        assert.uuid(uuid, 'routing key uuid suffix');
-        assert.string(pollerName, 'poller name suffix');
-        assert.object(results);
-
-        return messenger.publish(
-            Constants.Protocol.Exchanges.Events.Name,
-            ['poller.alert', pollerName, uuid].join('.'),
-            new Result({ value: results })
-        );
-    };
-
-
     TaskProtocol.prototype.requestPollerCache = function (workItemId, options) {
         assert.string(workItemId);
 

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -398,16 +398,6 @@ describe("Event protocol subscribers", function () {
                         version:'1.0',
                         createdAt: createTime
                     });
-                /* be compatible with legacy node event format */
-                expect(messenger.publish.secondCall).to.have.been.calledWith(
-                    'on.events',
-                    'event.node',
-                    {
-                        type: 'node',
-                        action: testAction,
-                        nodeId: testNodeId,
-                        nodeType: 'compute'
-                    });
                 expect(hook.publish).to.have.been.calledOnce;
                 expect(hook.publish).to.have.been.calledWith({
                         type: 'node',
@@ -444,17 +434,6 @@ describe("Event protocol subscribers", function () {
                         data: testData,
                         version:'1.0',
                         createdAt: createTime
-                    });
-                /* be compatible with legacy node event format */
-                expect(messenger.publish.secondCall).to.have.been.calledWith(
-                    'on.events',
-                    'event.node',
-                    {
-                        type: 'node',
-                        action: testAction,
-                        nodeId: testNodeId,
-                        nodeType: 'compute',
-                        data: testData
                     });
             });
         });
@@ -601,7 +580,6 @@ describe("Event protocol subscribers", function () {
     describe("publish heartbeat event", function () {
         it("should publish heartbeat event", function () {
             var eventTypeId = 'rackhd.on-tftp';
-            var legacyRoutingKey = eventTypeId;
             var data = {};
 
             var eventData = {
@@ -621,10 +599,6 @@ describe("Event protocol subscribers", function () {
                     'on.events',
                     'heartbeat.updated.information.' + eventTypeId,
                     eventData);
-                expect(messenger.publish.secondCall).to.be.calledWith(
-                    'on.heartbeat',
-                    legacyRoutingKey,
-                    { value: data });
             });
         });
     });

--- a/spec/lib/protocol/task-spec.js
+++ b/spec/lib/protocol/task-spec.js
@@ -589,18 +589,6 @@ describe("Task protocol functions", function() {
         });
     });
 
-    describe("publishPollerAlert", function() {
-        //NOTE: no matching internal code to listen for these events
-        it("should publish a poller alert event", function() {
-            var data = { foo: 'bar' },
-                uuid = helper.injector.get('uuid'),
-                testUuid = uuid.v4(),
-                pollerName = 'sdr';
-            messenger.publish.resolves();
-            return task.publishPollerAlertLegacy(testUuid, pollerName, data);
-        });
-    });
-
     describe("requestPollerCache", function() {
         it("should subscribe and receive requestPollerCache results", function() {
             var testWorkitemId = 'somestring',


### PR DESCRIPTION
Remove Legacy events format support for the coming 2.0 release. the new event notification formats could be referenced at http://rackhd.readthedocs.io/en/latest/rackhd/event_notification.html


@RackHD/corecommitters @iceiilin @sunnyqianzhang @nortonluo

Jenkins: Depends on https://github.com/RackHD/on-tasks/pull/419