### PR TITLE
handle undefined graphs safely

### DIFF
--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -355,11 +355,15 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
 
         return waterline.graphobjects.findOne(query, options)
         .then(function(graph) {
-            return {
-                graphId: graph.instanceId,
-                context: graph.context,
-                task: graph.tasks[data.taskId]
-            };
+            if (_.isEmpty(graph)) {
+                return undefined;
+            } else {
+                return {
+                    graphId: graph.instanceId,
+                    context: graph.context,
+                    task: graph.tasks[data.taskId]
+                };
+            }
         });
     };
 

--- a/spec/lib/workflow/stores/mongo-spec.js
+++ b/spec/lib/workflow/stores/mongo-spec.js
@@ -323,6 +323,28 @@ describe('Task Graph mongo store interface', function () {
         });
     });
 
+    it('getTaskById should return undefined when graph not found', function(){
+        var task1 = uuid.v4();
+
+        var data = {
+            taskId: task1,
+            graphId: uuid.v4()
+        };
+        waterline.graphobjects.findOne.resolves(undefined);
+
+        return mongo.getTaskById(data)
+        .then(function(result) {
+            expect(waterline.graphobjects.findOne).to.have.been.calledOnce;
+            var fields = { fields: { _id: 0, instanceId: 1, context: 1, tasks: {} } };
+            fields.fields.tasks[task1] = 1;
+            expect(waterline.graphobjects.findOne).to.have.been.calledWith(
+                { instanceId: data.graphId },
+                fields
+            );
+            expect(result).to.equal(undefined);
+        });
+    });
+
     it('getActiveGraphById', function() {
         var graphId = uuid.v4();
         waterline.graphobjects.findOne.resolves();


### PR DESCRIPTION
Partially fixes https://rackhd.atlassian.net/browse/RAC-637
supports https://github.com/RackHD/on-taskgraph/pull/226

@pscharla @RackHD/corecommitters 

Just return the undefined instead of crashing trying to query it. 