### PR TITLE
Refine timeout log

### DIFF
--- a/lib/common/messenger.js
+++ b/lib/common/messenger.js
@@ -363,10 +363,11 @@ function messengerFactory(
 
             return context.reject (
                 new Errors.RequestTimedOutError(
-                    'Request Timed Out (%s:%s:%s).'.format(
+                    'Request Timed Out (%s:%s:%s). %s ms'.format(
                         context.name,
                         context.routingKey,
-                        context.type || 'Object'
+                        context.type || 'Object',
+                        context.timeoutDuration || self.timeout
                     )
                 )
             );


### PR DESCRIPTION
there's no time out value for 'message: Request Timed Out' message, add it

@RackHD/corecommitters @iceiilin @yyscamper @leoyjchang 