### PR TITLE
Reduce unittest memory consumption

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -62,6 +62,7 @@ chai.Assertion.addMethod('stringify', function (target) {
  */
 var di = require('di');
 var dihelper = require('../lib/di')(di, __dirname);
+var core = require('../index')(di, '..');
 
 function provider(object) {
     var provides = _.detect(object.annotations, function (annotation) {
@@ -121,8 +122,6 @@ global.helper = {
 
     setupInjector: function (overrides) {
         // Start with the core dependencies.
-        var core = require('../index')(di, '..');
-
         var dependencies = _.flattenDeep([
             core.injectables,
             core.workflowInjectables


### PR DESCRIPTION
Originally, unittest require modules in every round, it consumes a lot of memory, the problems is
when CI/CD environment is in heavy load, it's easy to cause 'Error timeout of 10000ms exceeded. Ensure the done() callback is being called in this test.' due to lack of memory.. it's not necessary to consume unnecessary CPU and memory resources


Now move 'require' from every setupInjector() to global to avoid unnecessary requiring modules, it wouldn't affect RackHD functions, only limit to unittests, and all unit test cases have pass. benefits are
1. memory consumption reduce from ~500MB to ~300MB
2. unit test time decrease from ~17s to ~10s for 'on-core' unit test.  (4 cores/8GB mem in local machine), travisci unit test time decrease from ~27s to ~16s.

@RackHD/corecommitters @yyscamper @iceiilin @PengTian0 @leoyjchang 
