### PR TITLE
Add process.cwd into di path

### DIFF
--- a/lib/di.js
+++ b/lib/di.js
@@ -482,6 +482,7 @@ function setupDiHelper(di, defaultDirectory) {
     var requireResult =  _requireFile (requireMe, currentDirectory) ||
                          _requireFile (requireMe, defaultDirectory) ||
                          _requireFile (requireMe, __dirname) ||
+                         _requireFile (requireMe, process.cwd()) ||
                          _requireFile (requireMe, (void 0));
 
     if(!exists(requireResult)) {


### PR DESCRIPTION
## Problem

Recently, we found below issue occurs in some systems.  The di cannot find the "consul" even I am sure the "consul" has been correctly installed `on-taskgraph/node_modules"
```
/RackHD/on-core/lib/di.js:492
       throw new Error('dihelper incapable of finding specified file for require filename:' +
       ^

Error: dihelper incapable of finding specified file for require filename:consul, directories:(/RackHD/on-core, /RackHD/on-core/lib)
    at _require (/RackHD/on-core/lib/di.js:492:13)
    at Object.requireWrapper (/RackHD/on-core/lib/di.js:518:13)
    at Object.<anonymous> (/RackHD/on-taskgraph/index.js:25:20)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:13
```

## Root Cause
The di helper function [`requireWrapper`](https://github.com/RackHD/on-core/blob/7b015701917e72b05a69518381cbbdb75fb3ff85/lib/di.js#L482) only search the input directory or the `__dirname` (This is on-core directory since the dihelper is placed in on-core).
```javascript
    var requireResult =  _requireFile (requireMe, currentDirectory) ||
                         _requireFile (requireMe, defaultDirectory) ||
                         _requireFile (requireMe, __dirname) ||
                         _requireFile (requireMe, (void 0));
```

If we install `on-core` via `npm install` for on-taskgraph repo, there is no problem. But in our development environment, we often create a software link of on-core, so that a change to on-core will apply to all other repo (on-http/on-taskgraph/on-tasks/on-dhcp-proxy/on-tftp). This surely bring a lot convenience for developer. But the problem is npm search modules use the "original path" or symbol, and it usually fails to find the module. For example, if the symbol link for on-core is as following:

```
/home/rackhd/src
    |-- on-core
    |-- on-tasks
    |-- on-taskgraph
               |-- node_modules
                          |-- consul
                          |-- on-core  -> /home/rackhd/src/on-core
    |-- on-http
    |--
```

The `requireWrapper` is put in on-core, so `__dirname` is on-core, in npm, it use `/home/onrack/src/on-core` rather than `/home/rackhd/src/on-taskgraph/node_modules/on-core`, but the `consul` is not under `/home/onrack/src/on-core`, so di failed to find the module `consul`.

## Possible Solution
One of simple fix is to explicitly specify the di search directory for every module, for example:
```javascript
// remember that the following `__dirname` in on-taskgraph is the on-taskgraph directory.
helper.requireWrapper('consul', 'consul', undefined, __dirname)
```

Another possible solution (This is my PR's choice) is always adding the process directory into the di search path, so that we can still keep the following simplified requireWrapper usage
```javascript
helper.requireWrapper('consul', 'consul')
```

## Advantage:
Keep the simplified usage for `requireWrapper`, it benefits for all modules. Since `requireWrapper` is only a helper function, it is reasonable to add such functionality.

## Disadvantage:
There will be confusion if both `on-core` and `on-taskgraph` install different `consul` version, in my PR, the on-core's `consul` will take precedence, the `on-taskgraph` 's consul will be ignored.

@lanchongyizu @RackHD/corecommitters @iceiilin 


