### PR TITLE
replace keyword "$" with "___" in mongo to avoid conflict

### DIFF
--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -226,6 +226,8 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
             new: true,
             upsert: true
         };
+
+        exports._replaceKeyword(definition, '$', '___');
         return waterline.taskdefinitions.findAndModifyMongo(query, {}, definition, options);
     };
 
@@ -292,6 +294,8 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
                 instanceId: 1
             }
         };
+
+        exports._replaceKeyword(graph, '$', '___');
         return waterline.graphobjects.findAndModifyMongo(query, {}, graph, options);
     };
 
@@ -358,6 +362,7 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
             if (_.isEmpty(graph)) {
                 return undefined;
             } else {
+                exports._replaceKeyword(graph, '___', '$');
                 return {
                     graphId: graph.instanceId,
                     context: graph.context,
@@ -1057,6 +1062,33 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
         };
 
         return waterline.graphobjects.findOneMongo(query);
+    };
+
+    /**
+     * Replace document keywords which start with one string
+     * This is to avoid conflict of keywords between RackHD document and mongodb
+     * @param {Object} data - the document that needs to be transformed
+     * @param {String} beginSrc - the key that starts with this string will be replaced
+     * @param {String} beginDst - the key that will be used in the data base
+     * @memberOf store
+     */
+    exports._replaceKeyword = function(data, beginSrc, beginDst) {
+
+        _.map(data, function(value, key){
+
+            if ((typeof key === "string") && (key.startsWith(beginSrc))) {
+                var newKey = beginDst + key.slice(beginSrc.length);
+                data[newKey] = value;
+                delete data[key];
+                key = newKey;
+            }
+
+            if (typeof value === "object") {
+                exports._replaceKeyword(value, beginSrc, beginDst);
+                data[key] = value;
+            }
+        });
+
     };
 
     return exports;


### PR DESCRIPTION
Fix https://rackhd.atlassian.net/browse/RAC-4643 "Current RackHD is not compatible with mongodb v2.6.10"

It is caused by conflict keyword "$ref" in both mongoDB and task schema. It is probably that mongodb added compulsory check in version >= 2.6.10, which uncovered this problem.

Since task schema is added to mongoDB when loading task defenition and running a workflow, this fix transforms keyword beginning with "$" to "___" when adding documents in "graphobjects" and "taskdefinition" collection, and recover it after being retrieved from mongodb for task schema validation.

I only add this replacement in these three specific points to minimize the negative impact on performance for recursively tracing "$" inside a JSON data. Besides, restricting this operation in mongo.js to not influence   the business logic of taskgraph, neither other database that rackhd would adopt and doesn't have this conflict.

@yyscamper @brianparry @nortonluo @lanchongyizu 