### PR TITLE
Modifying name and location of smi config json

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -45,7 +45,7 @@ function constantsFactory (path) {
             Files: {
                 Global: process.env.MONORAIL_CONFIG || '/opt/monorail/config.json',
                 OnRack: '/opt/onrack/etc/monorail.json',
-                Dell: '/opt/dell/wsmanConfig.json'
+                Dell: '/opt/monorail/smiConfig.json'
             }
         },
         WorkItems: {


### PR DESCRIPTION
Modifying name and location of smi config json used by the smi discovery and dell wsman inventory microservices.  

This serves two purposes:
   1) removes wsman from the name 
   2) pulls from a path that will be in both ansible and docker installations. 

This change should only affect the taskgraphs that invoke the SMI microservices.

Another PR to physically add the file to the monorail folder via the RackHD/RackHD repo should be committed around the same time.