### PR TITLE
Add subscribe sel events methods

### DIFF
--- a/lib/models/work-item.js
+++ b/lib/models/work-item.js
@@ -231,6 +231,23 @@ function WorkItemModelFactory (
                 obj.node = obj.node.toString();
             }
             return sanitize(obj, /_/ig, '.');
+        },
+
+        updatePollerAlertConfig: function updatePollerAlertConfig(pollerId, data) {
+            var query = {_id: this.mongo.objectId(pollerId)};
+            var update;
+            data.alerts = data.alerts || [];
+            if (data.isRemove){
+                update = {$pullAll: {'config.alerts': data.alerts}};
+            } else {
+                update = {$addToSet: {'config.alerts': {$each: data.alerts}}};
+            }
+            if (data.pollInterval) {
+                update.$set = {'pollInterval': data.pollInterval};
+            } else {
+                update.$set = {};
+            }
+            return this.updateMongo(query, update, {});
         }
     });
 

--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -420,14 +420,14 @@ function eventsProtocolFactory (
         return self.publishGraphEvent(graphId, 'progress.updated', data.nodeId, data);
     };
 
-    EventsProtocol.prototype.subscribeSelEvent = function (pollerId, nodeId, callback) {
+    EventsProtocol.prototype.subscribeSelEvent = function (severity, pollerId, nodeId, callback) {
         assert.isMongoId(pollerId, 'subscribeSelEvent requires pollerId');
         assert.isMongoId(nodeId, 'subscribeSelEvents requires nodeId');
         assert.func(callback, 'subscribeSelEvents requires callback function');
 
         return messenger.subscribe(
             Constants.Protocol.Exchanges.Events.Name,
-            'polleralert.sel.updated.critical.' + pollerId + '.' + nodeId,
+            'polleralert.sel.updated.%s.%s.%s'.format(severity, pollerId, nodeId),
             callback
         );
     };

--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -420,6 +420,18 @@ function eventsProtocolFactory (
         return self.publishGraphEvent(graphId, 'progress.updated', data.nodeId, data);
     };
 
+    EventsProtocol.prototype.subscribeSelEvent = function (pollerId, nodeId, callback) {
+        assert.isMongoId(pollerId, 'subscribeSelEvent requires pollerId');
+        assert.isMongoId(nodeId, 'subscribeSelEvents requires nodeId');
+        assert.func(callback, 'subscribeSelEvents requires callback function');
+
+        return messenger.subscribe(
+            Constants.Protocol.Exchanges.Events.Name,
+            'polleralert.sel.updated.critical.' + pollerId + '.' + nodeId,
+            callback
+        );
+    };
+
     return new EventsProtocol();
 }
 

--- a/spec/lib/models/work-item-spec.js
+++ b/spec/lib/models/work-item-spec.js
@@ -505,6 +505,46 @@ describe('Models.WorkItem', function () {
                     expect(newWorkItem[0].state).to.equal("inaccessible");
                 });
         });
+
+        it('should set poller alert configure', function() {
+            this.sandbox.stub(workitems, 'updateMongo').resolves();
+            this.sandbox.stub(workitems.mongo, 'objectId').returns('test_id');
+            var data = {alerts: [{tests: 'tests'}], isRemove: false};
+            return workitems.updatePollerAlertConfig('test_id', data)
+            .then(function(){
+                expect(workitems.updateMongo).to.be.calledOnce;
+                expect(workitems.updateMongo).to.be.calledWith(
+                    {_id: 'test_id'},
+                    {
+                        $addToSet: {'config.alerts': {$each: [{tests: 'tests'}]}},
+                        $set: {}
+                    },
+                    {}
+                );
+                expect(workitems.mongo.objectId).to.be.calledOnce;
+                expect(workitems.mongo.objectId).to.be.calledWith('test_id');
+            });
+        });
+
+        it('should unset poller alert configure', function() {
+            this.sandbox.stub(workitems, 'updateMongo').resolves();
+            this.sandbox.stub(workitems.mongo, 'objectId').returns('test_id');
+            var data = {isRemove: true, pollInterval: 5000};
+            return workitems.updatePollerAlertConfig('test_id', data)
+            .then(function(){
+                expect(workitems.updateMongo).to.be.calledOnce;
+                expect(workitems.updateMongo).to.be.calledWith(
+                    {_id: 'test_id'},
+                    {
+                        $pullAll: {'config.alerts': []},
+                        $set: {pollInterval: 5000}
+                    },
+                    {}
+                );
+                expect(workitems.mongo.objectId).to.be.calledOnce;
+                expect(workitems.mongo.objectId).to.be.calledWith('test_id');
+            });
+        });
     });
 });
 

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -603,4 +603,20 @@ describe("Event protocol subscribers", function () {
         });
     });
 
+    describe("subscribe SEL event", function () {
+        it("should subscrbe SEl event", function () {
+            var nodeId = "507f191e810c19729de860ea";
+            var pollerId = "507f191e810c19729de860ea";
+            var callbackStub = sinon.stub();
+            return events.subscribeSelEvent(pollerId, nodeId, callbackStub)
+            .then(function(){
+                expect(messenger.subscribe).to.have.been.calledWith(
+                    'on.events',
+                    'polleralert.sel.updated.critical.' + pollerId + '.' + nodeId,
+                    callbackStub
+                );
+            });
+        });
+    });
+
 });

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -608,11 +608,11 @@ describe("Event protocol subscribers", function () {
             var nodeId = "507f191e810c19729de860ea";
             var pollerId = "507f191e810c19729de860ea";
             var callbackStub = sinon.stub();
-            return events.subscribeSelEvent(pollerId, nodeId, callbackStub)
+            return events.subscribeSelEvent('information', pollerId, nodeId, callbackStub)
             .then(function(){
                 expect(messenger.subscribe).to.have.been.calledWith(
                     'on.events',
-                    'polleralert.sel.updated.critical.' + pollerId + '.' + nodeId,
+                    'polleralert.sel.updated.information.' + pollerId + '.' + nodeId,
                     callbackStub
                 );
             });


### PR DESCRIPTION
To implement feature for subscribing sel events, two changes are made:
1. Add AMQP methods for subscribeSelEvents
2. Add update poller configure methods to set SEL events filtering