### PR TITLE
fix createIndexes problems

### DIFF
--- a/lib/common/model.js
+++ b/lib/common/model.js
@@ -138,6 +138,23 @@ function ModelFactory (
             });
         },
 
+        dropMongoIndexes: function() {
+            return this.runNativeMongo('dropIndexes');
+        },
+
+        dropIndexes: function() {
+            var self = this;
+            return Promise.resolve()
+            .then(function() {
+                switch(self.connection.toString()) {
+                    case 'mongo':
+                        return self.dropMongoIndexes();
+                    default:
+                        break;
+                }
+            });
+        },
+
         /**
          * Create indexes for different database
          *

--- a/lib/services/waterline.js
+++ b/lib/services/waterline.js
@@ -13,7 +13,8 @@ WaterlineServiceFactory.$inject = [
     'MongoAdapter',
     'PostgreSQLAdapter',
     '_',
-    '$injector'
+    '$injector',
+    'Logger'
 ];
 
 function WaterlineServiceFactory(
@@ -24,8 +25,11 @@ function WaterlineServiceFactory(
     MongoAdapter,
     PostgreSQLAdapter,
     _,
-    injector
+    injector,
+    Logger
 ) {
+    var logger = Logger.initialize(WaterlineServiceFactory);
+
     function WaterlineService () {
         this.startupPriority = 2;
         this.service = new Waterline();
@@ -125,8 +129,23 @@ function WaterlineServiceFactory(
         .then(function() {
             //it's OK to create indexes multiple times, so the code isn't protected by initialized
             //checking.
+            //
+            //For MongoDB 3.4+, creating indexes with same keys but different options throws errors.
+            //And the options `primaryKey: true` or `unique: true` in waterline models
+            //create indexes with option `{unique: true, sparse: true}` when waterline
+            //is initialized, so dropIndexes is called before createIndexes.
+            //
+            //Catching errors is because:
+            //  (1) When it fails to create indexes, the service still works.
+            //  (2) If errors are thrown, waterline isn't teardowned.
             return Promise.map(_.values(self.ontology.collections), function (collection) {
-                return collection.createIndexes();
+                return collection.dropIndexes()
+                .then(function() {
+                    return collection.createIndexes();
+                });
+            })
+            .catch(function(err) {
+                logger.error("Error creating indexes ", { error: err});
             });
         })
         .then(function() {

--- a/spec/lib/services/waterline-spec.js
+++ b/spec/lib/services/waterline-spec.js
@@ -25,19 +25,22 @@ describe('Services.Waterline', function () {
 
     describe('start', function () {
         it('should start service and resolve', function() {
+            var dropIndexesStub = this.sandbox.stub().resolves();
             var createIndexesStub = this.sandbox.stub().resolves();
             waterline.service.initialize = this.sandbox.spy(function(cfg,callback) {
                 var ontology = {
                     collections:{
                         'testModel': {
                             identity: 'test',
-                            createIndexes: createIndexesStub
+                            createIndexes: createIndexesStub,
+                            dropIndexes: dropIndexesStub
                         }
                     }
                 };
                 callback(undefined, ontology);
             });
             return waterline.start().then(function() {
+                expect(dropIndexesStub).to.have.been.calledOnce;
                 expect(createIndexesStub).to.have.been.calledOnce;
             });
         });


### PR DESCRIPTION
For MongoDB 3.4+, creating indexes with same keys but different options throws errors.
And the options `primaryKey: true` or `unique: true` in waterline models create indexes with option `{unique: true, sparse: true}` when waterline is initialized, so dropIndexes is called before createIndexes.

Catching errors is because:
  (1) When it fails to create indexes, the service still works.
  (2) If errors are thrown, waterline isn't teardowned.

@RackHD/corecommitters 