### PR TITLE
[RAC-5456] add taskName and graphName into on-taskgraph log

### DIFF
--- a/lib/protocol/events.js
+++ b/lib/protocol/events.js
@@ -138,10 +138,12 @@ function eventsProtocolFactory (
     };
 
     EventsProtocol.prototype.publishTaskFinished = function (
-            domain, taskId, graphId, state, error, context, terminalOnStates) {
+            domain, taskId, taskName, graphId, graphName, state, error, context, terminalOnStates) {
         assert.string(domain);
         assert.string(taskId);
+        assert.string(taskName);
         assert.uuid(graphId);
+        assert.string(graphName);
         assert.string(state);
         assert.object(context);
         assert.arrayOfString(terminalOnStates);
@@ -149,7 +151,7 @@ function eventsProtocolFactory (
         return messenger.publish(
             Constants.Protocol.Exchanges.Events.Name,
             domain + '.' + 'task.finished',
-            { taskId: taskId, graphId: graphId, state: state, error: error,
+            { taskId: taskId, taskName:taskName, graphId: graphId, graphName: graphName, state: state, error: error,
                 context: context, terminalOnStates: terminalOnStates }
         );
     };

--- a/lib/workflow/messengers/messenger-AMQP.js
+++ b/lib/workflow/messengers/messenger-AMQP.js
@@ -35,8 +35,8 @@ function amqpMessengerFactory(
         return taskProtocol.subscribeRun(domain, callback);
     };
 
-    AMQPMessenger.prototype.publishRunTask = function(domain, taskId, taskName, graphId, graphName) {
-        return taskProtocol.run(domain, { taskId: taskId, taskName: taskName, graphId: graphId , graphName: graphName});
+    AMQPMessenger.prototype.publishRunTask = function(domain, taskId, graphId) {
+        return taskProtocol.run(domain, { taskId: taskId, graphId: graphId});
     };
 
     AMQPMessenger.prototype.subscribeCancelTask = function(callback) {

--- a/lib/workflow/messengers/messenger-AMQP.js
+++ b/lib/workflow/messengers/messenger-AMQP.js
@@ -35,8 +35,8 @@ function amqpMessengerFactory(
         return taskProtocol.subscribeRun(domain, callback);
     };
 
-    AMQPMessenger.prototype.publishRunTask = function(domain, taskId, graphId) {
-        return taskProtocol.run(domain, { taskId: taskId, graphId: graphId });
+    AMQPMessenger.prototype.publishRunTask = function(domain, taskId, taskName, graphId, graphName) {
+        return taskProtocol.run(domain, { taskId: taskId, taskName: taskName, graphId: graphId , graphName: graphName});
     };
 
     AMQPMessenger.prototype.subscribeCancelTask = function(callback) {
@@ -67,10 +67,13 @@ function amqpMessengerFactory(
         } else if (task.error) {
             errorMsg = task.error.toString();
         }
+      
         return eventsProtocol.publishTaskFinished(
             domain,
             task.instanceId,
+            task.definition.injectableName,
             task.context.graphId,
+            task.context.graphName,
             task.state,
             errorMsg,
             task.context,

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -359,7 +359,6 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
                 return undefined;
             } else {
                 return {
-                    domain: data.domain,
                     graphId: graph.instanceId,
                     context: graph.context,
                     task: graph.tasks[data.taskId]

--- a/lib/workflow/stores/mongo.js
+++ b/lib/workflow/stores/mongo.js
@@ -359,6 +359,7 @@ function mongoStoreFactory(waterline, Promise, Constants, Errors, assert, _) {
                 return undefined;
             } else {
                 return {
+                    domain: data.domain,
                     graphId: graph.instanceId,
                     context: graph.context,
                     task: graph.tasks[data.taskId]

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -140,7 +140,9 @@ describe("Event protocol subscribers", function () {
                 domain = 'default',
                 data = {
                     taskId: uuid.v4(),
+                    taskName: 'taskName',
                     graphId: uuid.v4(),
+                    graphName: 'graphName',
                     state: 'succeeded',
                     error: null,
                     context: {},
@@ -159,7 +161,9 @@ describe("Event protocol subscribers", function () {
                 return events.publishTaskFinished(
                     domain,
                     data.taskId,
+                    data.taskName,
                     data.graphId,
+                    data.graphName,
                     data.state,
                     data.error,
                     data.context,

--- a/spec/lib/workflow/messengers/messenger-AMQP-spec.js
+++ b/spec/lib/workflow/messengers/messenger-AMQP-spec.js
@@ -71,12 +71,12 @@ describe('Task/TaskGraph AMQP messenger plugin', function () {
     });
 
     it('should wrap the task protocol run method', function() {
-        return amqp.publishRunTask('default', 'testtaskid', 'testtaskname', 'testgraphid', 'testgraphname')
+        return amqp.publishRunTask('default', 'testtaskid', 'testgraphid')
         .then(function() {
             expect(taskProtocol.run).to.have.been.calledOnce;
             expect(taskProtocol.run).to.have.been.calledWith(
                 'default',
-                { taskId: 'testtaskid', taskName: 'testtaskname', graphId: 'testgraphid', graphName:'testgraphname'}
+                { taskId: 'testtaskid', graphId: 'testgraphid'}
             );
         });
     });


### PR DESCRIPTION
**Background**
The current on-taskgraph log misses task and graph name, which makes developers hard to track workflow's actual behavior. It will be beneficial if adding their name into it. For more details, you can go to 
[https://rackhd.atlassian.net/browse/RAC-5456](url)

**Details**
To solve this problem, change the code of three repos: on-core, on-tasks, on-taskgraph. In on-core repo, add taskName and graphName into the  the function eventsProtocol.publishTaskFinished. Besides, add the responding changes to the unit test files.
Jenkins depends on: https://github.com/RackHD/on-tasks/pull/482, https://github.com/RackHD/on-taskgraph/pull/263

**TestDone**
test it successfully on ubuntu 14.04.exsi vm

**Reviewer**
@iceiilin @pengz1 

