### PR TITLE
clean up unit-test errors when it timeouts

### DIFF
--- a/lib/services/argument-handler.js
+++ b/lib/services/argument-handler.js
@@ -6,12 +6,14 @@ module.exports = argumentHandlerServiceFactory;
 
 argumentHandlerServiceFactory.$provide = 'Services.ArgumentHandler';
 argumentHandlerServiceFactory.$inject = [
+    'Promise',
     '_',
     'Services.Configuration',
     'LogEvent'
 ];
 
 function argumentHandlerServiceFactory(
+    Promise,
     _,
     config,
     LogEvent
@@ -48,12 +50,16 @@ function argumentHandlerServiceFactory(
      * Start the argument handler service.
      */
     ArgumentHandlerService.prototype.start = function() {
-        //Configure the log colorful output
-        var colorEnable = this._getValue(['color', 'logColorEnable'], false);
-        LogEvent.setColorEnable(colorEnable);
+        var self = this;
+        return Promise.try(function() {
+            //Configure the log colorful output
+            var colorEnable = self._getValue(['color', 'logColorEnable'], false);
+            LogEvent.setColorEnable(colorEnable);
+        });
     };
 
     ArgumentHandlerService.prototype.stop = function() {
+        return Promise.resolve();
     };
 
     return new ArgumentHandlerService();

--- a/lib/services/core.js
+++ b/lib/services/core.js
@@ -26,16 +26,13 @@ function coreServiceFactory(Promise, _, injector) {
     }
 
     CoreService.prototype.start = function start() {
-        var self = this,
-            services = injector.getMatching(/^Services\.(?!Core).*/);
+        var services = injector.getMatching(/^Services\.(?!Core).*/);
 
         services = sortByPriority(services);
 
         return Promise.reduce(services, function (accumulator, service) {
             return service.start();
-        }, {}).then(function () {
-            return self;
-        });
+        }, {});
     };
 
     CoreService.prototype.stop = function stop() {

--- a/lib/services/lookup.js
+++ b/lib/services/lookup.js
@@ -533,7 +533,9 @@ function lookupServiceFactory(
         });
     };
 
-    LookupService.prototype.start = function () {};
+    LookupService.prototype.start = function () {
+        return Promise.resolve();
+    };
 
     LookupService.prototype.stop = function () {
         return Promise.resolve();

--- a/lib/services/statsd.js
+++ b/lib/services/statsd.js
@@ -42,17 +42,16 @@ function statsdServiceFactory(
         });
 
         this.increment('process.started');
-
         this.started = true;
 
         return Promise.resolve();
     };
 
     StatsDService.prototype.stop = function () {
-        this.increment('process.stopped');
-
-        this.started = false;
-
+        if(this.started) {
+            this.increment('process.stopped');
+            this.started = false;
+        }
         return Promise.resolve();
     };
 

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -107,7 +107,6 @@ global.helper = {
     injector: undefined,
 
     start: function (overrides) {
-        var self = this;
         // Setup test injector.
         this.setupInjector(overrides);
 
@@ -115,9 +114,8 @@ global.helper = {
         this.setupTestConfig();
 
         // Start the core services.
-        return this.injector.get('Services.Core').start().then(function (core) {
-            self.core = core;
-        });
+        this.core = this.injector.get('Services.Core');
+        return this.core.start();
     },
 
     setupInjector: function (overrides) {

--- a/spec/lib/common/arp-spec.js
+++ b/spec/lib/common/arp-spec.js
@@ -22,16 +22,13 @@ describe('ARPCache', function () {
     before(function () {
         arpCache = helper.injector.get('ARPCache');
         fs = helper.injector.get('fs');
-        sinon.stub(fs, 'readFileAsync');
     });
 
     beforeEach(function() {
-        fs.readFileAsync.reset();
+        this.sandbox.stub(fs, 'readFileAsync');
     });
 
-    helper.after(function () {
-        fs.readFileAsync.restore();
-    });
+    helper.after();
 
     describe("Handle ARP Entry", function(){
         it('should parse ARP data', function() {

--- a/spec/lib/common/connection-spec.js
+++ b/spec/lib/common/connection-spec.js
@@ -33,7 +33,7 @@ describe('Connection', function () {
         this.subject = new Connection({url: ''}, {}, 'test');
     });
 
-    after(function() {
+    helper.after(function() {
         sandbox.restore();
     });
 

--- a/spec/lib/common/file-loader-spec.js
+++ b/spec/lib/common/file-loader-spec.js
@@ -12,28 +12,17 @@ describe('FileLoader', function () {
     before(function () {
         FileLoader = helper.injector.get('FileLoader');
         fs = helper.injector.get('fs');
-
         this.subject = new FileLoader();
-
-        sinon.stub(fs, 'writeFileAsync');
-        sinon.stub(fs, 'readFileAsync');
-        sinon.stub(fs, 'readdirAsync');
-        sinon.stub(fs, 'statAsync');
     });
 
     beforeEach(function() {
-        fs.writeFileAsync.reset();
-        fs.readFileAsync.reset();
-        fs.readdirAsync.reset();
-        fs.statAsync.reset();
+        this.sandbox.stub(fs, 'writeFileAsync');
+        this.sandbox.stub(fs, 'readFileAsync');
+        this.sandbox.stub(fs, 'readdirAsync');
+        this.sandbox.stub(fs, 'statAsync');
     });
 
-    helper.after(function () {
-        fs.writeFileAsync.restore();
-        fs.readFileAsync.restore();
-        fs.readdirAsync.restore();
-        fs.statAsync.restore();
-    });
+    helper.after();
 
     describe('put', function () {
         it('should write the contents to the specified file', function () {

--- a/spec/lib/common/system-uuid-spec.js
+++ b/spec/lib/common/system-uuid-spec.js
@@ -6,7 +6,7 @@ describe("SystemUuid", function() {
     var regEx = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
     var fs;
     var uuid = '0e2c320f-f29e-47c6-be18-0c833e0f080c';
-    
+
     before(function () {
         helper.setupInjector();
         subject = helper.injector.get('SystemUuid');
@@ -14,10 +14,10 @@ describe("SystemUuid", function() {
         sinon.stub(fs, 'readFileAsync');
     });
 
-    helper.after(function() {
+    after(function() {
         fs.readFileAsync.restore();
     });
-    
+
     beforeEach(function() {
         fs.readFileAsync.reset();
     });

--- a/spec/lib/protocol/events-spec.js
+++ b/spec/lib/protocol/events-spec.js
@@ -24,28 +24,15 @@ describe("Event protocol subscribers", function () {
 
         testSubscription = new Subscription({},{});
         testMessage = new Message({},{},{});
-        sinon.stub(testMessage);
-        sinon.stub(messenger, 'request');
-        sinon.stub(messenger, 'publish');
-        sinon.stub(hook, 'publish').resolves();
     });
 
     beforeEach(function() {
-        messenger.request.reset();
-        messenger.publish.reset();
-        hook.publish.reset();
-	    clock = sinon.useFakeTimers(new Date(2011,9,1).getTime());
-	    createTime = new Date();
-    });
-
-    afterEach(function() {
-        clock.restore();
-    });
-
-    after(function() {
-        messenger.request.restore();
-        messenger.publish.restore();
-        hook.publish.restore();
+        this.sandbox.stub(testMessage);
+        this.sandbox.stub(messenger, 'request');
+        this.sandbox.stub(messenger, 'publish');
+        this.sandbox.stub(hook, 'publish').resolves();
+        clock = this.sandbox.useFakeTimers(new Date(2011,9,1).getTime());
+        createTime = new Date();
     });
 
     helper.after();
@@ -56,7 +43,7 @@ describe("Event protocol subscribers", function () {
             //NOTE: no matching internal code to listen for these events
             var nodeId = "507f191e810c19729de860ea", //mongoId format
                 data = {foo: 'bar'};
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -77,7 +64,7 @@ describe("Event protocol subscribers", function () {
             //NOTE: no matching internal code to listen for these events
             var nodeId = "507f191e810c19729de860ea", //mongoId format
                 data = {foo: 'bar'};
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -98,7 +85,7 @@ describe("Event protocol subscribers", function () {
             //NOTE: no matching internal code to listen for these events
             var nodeId = "507f191e810c19729de860ea", //mongoId format
                 data = {foo: 'bar'};
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -119,7 +106,7 @@ describe("Event protocol subscribers", function () {
             //NOTE: no matching internal code to listen for these events
             var nodeId = "507f191e810c19729de860ea", //mongoId format
                 data = {foo: 'bar'};
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -146,7 +133,7 @@ describe("Event protocol subscribers", function () {
                     context: {},
                     terminalOnStates: ['failed', 'timeout']
                 };
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -176,7 +163,7 @@ describe("Event protocol subscribers", function () {
                     nodeId: nodeId,
                     data: 'test data'
                 };
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -200,7 +187,7 @@ describe("Event protocol subscribers", function () {
 
         it("should publish and subscribe to NodeNotification messages without data", function(){
             var nodeId = '57a86b5c36ec578876878294';
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback(testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -224,7 +211,7 @@ describe("Event protocol subscribers", function () {
             var data = {
                     data: 'test data'
                 };
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback(data,testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -246,7 +233,7 @@ describe("Event protocol subscribers", function () {
         });
 
         it("should publish and subscribe to BroadcastNotification messages without data", function(){
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback(testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -273,7 +260,7 @@ describe("Event protocol subscribers", function () {
                 graphId = uuid.v4(),
                 status = 'testStatus',
                 nodeId = 'abc';
-            messenger.subscribe = sinon.spy(function(a, b, callback) {
+            messenger.subscribe = this.sandbox.spy(function(a, b, callback) {
                 callback({status: status}, testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -299,7 +286,7 @@ describe("Event protocol subscribers", function () {
                 graphId = uuid.v4(),
                 status = 'testStatus',
                 nodeId = 'abc';
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback({status:status},testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -321,7 +308,7 @@ describe("Event protocol subscribers", function () {
             var uuid = helper.injector.get('uuid'),
                 skuId = uuid.v4(); // uuid format
             var nodeId = "507f191e810c19729de860ea";
-            messenger.subscribe = sinon.spy(function(a,b,callback) {
+            messenger.subscribe = this.sandbox.spy(function(a,b,callback) {
                 callback({sku:skuId},testMessage);
                 return Promise.resolve(testSubscription);
             });
@@ -607,7 +594,7 @@ describe("Event protocol subscribers", function () {
         it("should subscrbe SEl event", function () {
             var nodeId = "507f191e810c19729de860ea";
             var pollerId = "507f191e810c19729de860ea";
-            var callbackStub = sinon.stub();
+            var callbackStub = this.sandbox.stub();
             return events.subscribeSelEvent('information', pollerId, nodeId, callbackStub)
             .then(function(){
                 expect(messenger.subscribe).to.have.been.calledWith(

--- a/spec/lib/services/environment-spec.js
+++ b/spec/lib/services/environment-spec.js
@@ -11,14 +11,13 @@ describe('Services.Environment', function () {
     before(function () {
         this.subject = helper.injector.get('Services.Environment');
         waterline = helper.injector.get('Services.Waterline');
-        sinon.stub(waterline.environment, "findOne");
+    });
+
+    beforeEach('set up mocks', function() {
+        this.sandbox.stub(waterline.environment, "findOne");
     });
 
     helper.after();
-
-    after(function() {
-        waterline.environment.findOne.restore();
-    });
 
     var global = {
         identifier: 'global',
@@ -71,7 +70,7 @@ describe('Services.Environment', function () {
     
     it('should set a key-value', function() {
         var global = {};
-        sinon.stub(waterline.environment, "update", function(where, data) {
+        this.sandbox.stub(waterline.environment, "update", function(where, data) {
             global = data.data;
             return [global];
         });

--- a/spec/lib/services/heartbeat-spec.js
+++ b/spec/lib/services/heartbeat-spec.js
@@ -26,9 +26,8 @@ describe('Heartbeat', function () {
         }
     };
     var events = {
-        publishHeartbeatEvent: sandbox.stub().returns(
-            Promise.resolve()
-        )
+        publishHeartbeatEvent: sandbox.stub().returns(Promise.resolve()),
+        publishUnhandledError: sandbox.stub()
     };
     var dns = {
         lookupServiceAsync: sandbox.stub(),

--- a/spec/lib/services/waterline-spec.js
+++ b/spec/lib/services/waterline-spec.js
@@ -38,7 +38,7 @@ describe('Services.Waterline', function () {
                 callback(undefined, ontology);
             });
             return waterline.start().then(function() {
-                expect(createIndexesStub).to.have.been.called;
+                expect(createIndexesStub).to.have.been.calledOnce;
             });
         });
 


### PR DESCRIPTION
**Backgroud**
This is for the story https://rackhd.atlassian.net/browse/RAC-5639.

During work of https://rackhd.atlassian.net/browse/RAC-5593, we found many unit test cases won't do the clean-up work if running into failure (aka exception handler) , so the plan is to add clean-up work in unit test cases.

**TEST**
It's tested in sandbox:
http://10.62.59.175:8080/job/on-core_jamie/


@RackHD/corecommitters 