### PR TITLE
RAC-5804 - Change default config messages to be info

### DIFF
--- a/lib/services/configuration.js
+++ b/lib/services/configuration.js
@@ -76,7 +76,7 @@ function configurationServiceFactory(
         var value = nconf.get(key);
 
         if (value === undefined) {
-            logger.warning('Configuration value is undefined, using default (%s => %s).'.format(
+            logger.info('Configuration value is undefined, using default (%s => %s).'.format(
                 key,
                 defaults
             ));


### PR DESCRIPTION
log message that reports default config settings is
being made level info instead of warning.

'Configuration value is undefined, using default'