### PR TITLE
RAC-5819 - Clean up configuration-related logs

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -44,7 +44,6 @@ function constantsFactory (path) {
         Configuration: {
             Files: {
                 Global: process.env.MONORAIL_CONFIG || '/opt/monorail/config.json',
-                OnRack: '/opt/onrack/etc/monorail.json',
                 Dell: '/opt/monorail/smiConfig.json'
             }
         },

--- a/lib/services/configuration.js
+++ b/lib/services/configuration.js
@@ -38,20 +38,28 @@ function configurationServiceFactory(
 
         nconf.argv().env();
 
-        if (fs.existsSync(Constants.Configuration.Files.Global)) {
-            nconf.file('global', Constants.Configuration.Files.Global);
-        } else if (fs.existsSync(Constants.Configuration.Files.OnRack)) {
-            //TODO: remove once OnRack build process adjusts for changes.
-            nconf.file('global', Constants.Configuration.Files.OnRack);
-        } else {
+        // global config load
+        try {
+            if (fs.existsSync(Constants.Configuration.Files.Global)) {
+                nconf.file('global', Constants.Configuration.Files.Global);
+            }
+        }
+        catch(e) {
             console.error('Failed to load configuration file:',
                 Constants.Configuration.Files.Global);
+            console.error(e.message);
         }
-        if (fs.existsSync(Constants.Configuration.Files.Dell)) {
-            nconf.file('dell', Constants.Configuration.Files.Dell);
-        } else {
+
+        // dell config load
+        try {
+            if (fs.existsSync(Constants.Configuration.Files.Dell)) {
+                nconf.file('dell', Constants.Configuration.Files.Dell);
+            }
+        }
+        catch(e) {
             console.error('Failed to load configuration file:',
                 Constants.Configuration.Files.Dell);
+            console.error(e.message);
         }
 
         var baseDirectory = path.resolve(__dirname + '/../..');

--- a/spec/lib/services/configuration-spec.js
+++ b/spec/lib/services/configuration-spec.js
@@ -65,13 +65,13 @@ describe(require('path').basename(__filename), function () {
                         'global', Constants.Configuration.Files.Global
                     );
                 });
-                it('applies defaults from the OnRack configuration file', function() {
+                it('applies defaults from the dell configuration file', function() {
                     fs.existsSync.withArgs(
-                        Constants.Configuration.Files.OnRack
+                        Constants.Configuration.Files.Dell
                     ).returns(true);
                     this.subject.load();
                     nconf.file.should.have.been.calledWith(
-                        'global', Constants.Configuration.Files.OnRack
+                        'dell', Constants.Configuration.Files.Dell
                     );
                 });
             });


### PR DESCRIPTION
- Raises an exception when the configuration actually
  fails during nconf load.  Previous message was based on
  file's existence.
- Remove old references to OnRack configurations