### PR TITLE
Make aggregated log column align and remove redundant field in logs

### DIFF
--- a/lib/serializables/log-event.js
+++ b/lib/serializables/log-event.js
@@ -51,9 +51,6 @@ function LogEventFactory (
             host: {
                 type: 'string'
             },
-            module: {
-                type: 'string'
-            },
             level: {
                 type: 'string',
                 enum: _.keys(Constants.Logging.Levels)
@@ -74,7 +71,7 @@ function LogEventFactory (
                 type: 'string'
             }
         },
-        required: [ 'module', 'level', 'timestamp', 'caller', 'subject' ]
+        required: [ 'level', 'timestamp', 'caller', 'subject' ]
     };
 
     Serializable.register(LogEventFactory, LogEvent);
@@ -83,10 +80,11 @@ function LogEventFactory (
         var statement = [];
 
         this.context = LogEvent.redact(this.context);
-        statement.push('[%s]'.format(this.level));
+        // The level length 8 is hardcoded here, as the loggest level up to now
+        // is 8, this might be subject to change when new log levels are added
+        // in the future
+        statement.push('[%s]'.format( _.pad(this.level, 8)));
         statement.push('[%s]'.format(this.timestamp));
-        statement.push('[%s]'.format(this.name));
-        statement.push('[%s]'.format(this.module));
         statement.push('[%s]'.format(
             this.subject.substring(this.subject.length - Constants.Logging.Context.Length)
         ));


### PR DESCRIPTION
To fix this issue:
https://rackhd.atlassian.net/browse/RAC-5515

What the code change did:
1. Make the severity level the same length in logs. e.g. [  info  ], [critical], they have the same length
2. Remove the fields like [on-taskgraph][ TaskGraph.TaskScheduler], as they don't provide very useful information but makes the logs complicated.

Before code change, the log is like this:
 0|taskgrap | [debug] [2017-08-09T08:53:30.463Z][on-taskgraph][ TaskGraph.TaskScheduler][ Server] Running job.

After the code change, the log is like:
0|taskgrap | [ debug  ] [2017-08-09T08:53:30.463Z] [ Server]Running job.


@anhou @pengz1 @iceiilin 