### PR TITLE
Add taskgraph status and task status when the taskgraph failed

### DIFF
--- a/lib/common/graph-progress.js
+++ b/lib/common/graph-progress.js
@@ -30,6 +30,7 @@ function graphProgressFactory(
             graphId: graph.instanceId,
             nodeId: graph.node,
             graphName: graph.name || 'Not available',
+            status: graph._status,
             progress: {
                 description: graphDescription || 'Not available',
             }
@@ -76,6 +77,7 @@ function graphProgressFactory(
         self.data.taskProgress = {
             taskId: taskId,
             taskName: task.friendlyName || 'Not available',
+            state: task.state,
             progress: taskProgress
         };
     };

--- a/spec/lib/common/graph-progress-spec.js
+++ b/spec/lib/common/graph-progress-spec.js
@@ -24,6 +24,7 @@ describe('GraphProgress', function() {
             instanceId: graphId,
             name: 'test graph name',
             node: 'nodeId',
+            status: 'failed',
             tasks: {}
         };
         graphDescription = 'test graph description';
@@ -41,6 +42,7 @@ describe('GraphProgress', function() {
             graphId: graphId,
             graphName: 'test graph name',
             nodeId: 'nodeId',
+            status: graph._status,
             progress: {
                 value: 0,
                 maximum: 1,
@@ -50,6 +52,7 @@ describe('GraphProgress', function() {
             taskProgress: {
                 taskId: taskId,
                 taskName: 'test task name',
+                state: 'pending',
                 progress: {
                     value: 1,
                     maximum: 4,

--- a/spec/lib/common/graph-progress-spec.js
+++ b/spec/lib/common/graph-progress-spec.js
@@ -24,7 +24,7 @@ describe('GraphProgress', function() {
             instanceId: graphId,
             name: 'test graph name',
             node: 'nodeId',
-            status: 'failed',
+            _status: 'failed',
             tasks: {}
         };
         graphDescription = 'test graph description';

--- a/spec/lib/services/graph-progress-spec.js
+++ b/spec/lib/services/graph-progress-spec.js
@@ -51,6 +51,7 @@ describe('Services.GraphProgress', function() {
                 graphId: graph.instanceId,
                 graphName: graph.name,
                 nodeId: graph.node,
+                status: graph._status,
                 progress: {
                     maximum: 1,
                     value: 0,
@@ -111,6 +112,7 @@ describe('Services.GraphProgress', function() {
                 graphId: graph.instanceId,
                 graphName: graph.name,
                 nodeId: graph.node,
+                status: graph._status,
                 progress: {
                     maximum: 1,
                     value: 1,
@@ -177,6 +179,7 @@ describe('Services.GraphProgress', function() {
                 instanceId: graphId,
                 name: 'test graph name',
                 node: 'nodeId',
+                _status: 'running',
                 tasks: {
                     'aTaskId': {
                         friendlyName: task.definition.friendlyName,
@@ -189,6 +192,7 @@ describe('Services.GraphProgress', function() {
                 graphId: graph.instanceId,
                 graphName: graph.name,
                 nodeId: graph.node,
+                status: graph._status,
                 progress: {
                     value: 0,
                     maximum: 1,
@@ -198,6 +202,7 @@ describe('Services.GraphProgress', function() {
                 taskProgress: {
                     taskId: task.instanceId,
                     taskName: task.definition.friendlyName,
+                    state: task.state,
                     progress: {
                         value: 0,
                         maximum: 100,
@@ -250,6 +255,7 @@ describe('Services.GraphProgress', function() {
                 graphId: graph.instanceId,
                 graphName: graph.name,
                 nodeId: 'nodeId',
+                status: graph._status,
                 progress: {
                     value: 1,
                     maximum: 1,
@@ -259,6 +265,7 @@ describe('Services.GraphProgress', function() {
                 taskProgress: {
                     taskId: task.taskId,
                     taskName: taskFriendlyName,
+                    state: graph.tasks[taskId].state,
                     progress: {
                         value: 100,
                         maximum: 100,


### PR DESCRIPTION
This is used to gather more information on task and taskgraph status when the task failed. Add the state field for both task and taskgraph so that the information is more clear. @iceiilin @pengz1 