### PR TITLE
Remove sources list, manually download snmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,6 @@ FROM nodesource/wheezy:4.4.6
 
 COPY . /RackHD/on-core/
 
-RUN echo "deb http://ftp.us.debian.org/debian wheezy main"                  >  /etc/apt/sources.list \
- && echo "deb http://ftp.us.debian.org/debian wheezy-updates main"          >> /etc/apt/sources.list \
- && echo "deb http://security.debian.org wheezy/updates main"               >> /etc/apt/sources.list \
- && echo "deb http://ftp.us.debian.org/debian wheezy main non-free"         >> /etc/apt/sources.list \
- && echo "deb http://ftp.us.debian.org/debian wheezy-updates main non-free" >> /etc/apt/sources.list \
- && echo "deb http://security.debian.org wheezy/updates main non-free"      >> /etc/apt/sources.list
-
 RUN cd /RackHD/on-core \
   && npm install --ignore-scripts --production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016, EMC, Inc.
+# Copyright 2016, EMC, Inc. 
 
 FROM nodesource/wheezy:4.4.6
 


### PR DESCRIPTION
in on-taskgraph

Signed-off-by: Joe Gorse <joseph.gorseiii@emc.com>
depends on: https://github.com/RackHD/on-taskgraph/pull/281