### PR TITLE
Converting http response to json if valid json

### DIFF
--- a/lib/common/http-tool.js
+++ b/lib/common/http-tool.js
@@ -200,6 +200,9 @@ function HttpFactory(assert, Promise, _) {
                     result.body += chunk;
                 });
                 response.on('end', function(){
+                    if(self.isJsonString(result.body)){
+                        result.body = JSON.parse(result.body);
+                    }
                     resolve(result);
                 });
             });            
@@ -217,6 +220,15 @@ function HttpFactory(assert, Promise, _) {
             self.settings = {};
             request.end();
         });    
+    };
+
+    HttpTool.prototype.isJsonString = function (str){
+        try {
+            JSON.parse(str);
+        } catch (e) {
+            return false;
+        }
+        return true;
     };
 
     return HttpTool;

--- a/spec/lib/common/http-tool-spec.js
+++ b/spec/lib/common/http-tool-spec.js
@@ -60,7 +60,7 @@ describe("HttpTool", function(){
     it('can handle secure http and non-standard port', function(){
         nock('https://mysite.emc.com:12345')
         .get('/non-standard-port/http-secure')
-        .reply(200, 'You are good');
+        .reply(200, '{"result": "You are good"}');
         
         requestSettings.url = 'https://mysite.emc.com:12345/non-standard-port/http-secure';
         requestSettings.method = 'GET';
@@ -70,7 +70,7 @@ describe("HttpTool", function(){
             return httpTool.runRequest();
         })
         .then(function(data){
-            expect(data).to.have.property('body').to.equal('You are good');
+            expect(data).to.have.property('body').to.have.property('result').to.equal('You are good');
         });
     });
 
@@ -132,7 +132,7 @@ describe("HttpTool", function(){
         requestSettings = {};
         
         nock(siteGen)
-        .post('/simple-post').reply(201, 'OK');
+        .post('/simple-post').reply(201, '{"result": "OK"}');
 
         requestSettings.url = siteGen + '/simple-post';
         requestSettings.method = 'POST';
@@ -143,7 +143,7 @@ describe("HttpTool", function(){
             return httpTool.runRequest();
         })
         .then(function(data){
-            expect(data).to.have.property('body').to.equal('OK');
+            expect(data).to.have.property('body').to.have.property('result').to.equal('OK');
         });
     });
 


### PR DESCRIPTION
Signed-off-by: Bala Balakumaran <bala.balakumaran@dell.com>

When a `Task.Base.Rest` is is used in a graph, it adds the outputs in the context which can then be refereed by subsequent tasks as `context.restData.body` however this is always a string. 

This PR allows the **body** to be converted to JSON if it is a valid JSON.
That way one can refer to ex: `context.restData.body.token`