### PR TITLE
Fix node 6/8 unit test

### DIFF
--- a/lib/models/local-user.js
+++ b/lib/models/local-user.js
@@ -50,7 +50,7 @@ function LocalUserModelFactory (Model, configuration) {
                 var iterations = hashConfig.iterations;
                 var salt = combined.slice(0, saltBytes);
                 var hash = combined.toString('binary', saltBytes);
-                var verify = crypto.pbkdf2Sync(password, salt, iterations, hashBytes);
+                var verify = crypto.pbkdf2Sync(password, salt, iterations, hashBytes, 'sha512');
                 return verify.toString('binary') === hash;
             }
         },
@@ -63,8 +63,7 @@ function LocalUserModelFactory (Model, configuration) {
             if (err) {
                 return next(err);
             }
-
-            crypto.pbkdf2(obj.password, salt, hashConfig.iterations, hashConfig.hashBytes, function(err, hash) { //jshint ignore: line
+            crypto.pbkdf2(obj.password, salt, hashConfig.iterations, hashConfig.hashBytes, "sha512", function(err, hash) { //jshint ignore: line
                 if (err) {
                     return next(err);
                 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "on-core",
   "version": "2.27.0",
   "description": "OnCore Library",
+  "//": "Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.",
   "main": "index.js",
   "scripts": {
     "doc": "jsdoc lib -r -d docs",
@@ -22,7 +23,7 @@
     "always-tail": "^0.2.0",
     "amqp": "0.2.3",
     "anchor": "^0.10.2",
-    "apache-crypt": "1.2.1",
+    "apache-crypt": "1.0.9",
     "assert-plus": "^1.0.0",
     "bluebird": "^2.8.0",
     "bson": "~0.4.22",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "always-tail": "^0.2.0",
     "amqp": "0.2.3",
     "anchor": "^0.10.2",
-    "apache-crypt": "1.0.9",
+    "apache-crypt": "1.2.1",
     "assert-plus": "^1.0.0",
     "bluebird": "^2.8.0",
     "bson": "~0.4.22",
@@ -69,11 +69,11 @@
     "jsdoc": "^3.3.0-alpha13",
     "jshint": "^2.5.11",
     "mocha": "^2.1.0",
-    "nock": "~3.5.0",
+    "nock": "~9.0.22",
     "sinon": "1.16.1",
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",
-    "supertest": "^0.15.0",
+    "supertest": "^1.2.0",
     "xunit-file": "0.0.6"
   }
 }

--- a/spec/lib/common/encryption-spec.js
+++ b/spec/lib/common/encryption-spec.js
@@ -85,9 +85,9 @@ describe('Encryption', function () {
             it('should generate correct hash data', function() {
                 var data = "rackhd.github.com";
                 this.subject.createHash(data, 'sha512', '$6$WeJknBPkDab')
-                    .should.equal('$6K02bHzduy/Y'); //jshint ignore:line
+                    .should.equal('$6$WeJknBPkDab$yRRWg5Kr1MCAbKkBtKyKtldb9DFDXidKHj.wQwOKO1TSHUKCvIi7x9QubOenwGfYXoBK0vvwKvNgIlW9Oc6O4.'); //jshint ignore:line
                 this.subject.createHash(data, 'sha256', '$5$WeJknBPkDab')
-                    .should.equal('$5VQYaJCqoZho');
+                    .should.equal('$5$WeJknBPkDab$t4J3IF.tD9H/2HFDjV.CpFN1ay5rmwa7maVkstEiyv9');
             });
         });
 

--- a/spec/lib/common/encryption-spec.js
+++ b/spec/lib/common/encryption-spec.js
@@ -85,9 +85,9 @@ describe('Encryption', function () {
             it('should generate correct hash data', function() {
                 var data = "rackhd.github.com";
                 this.subject.createHash(data, 'sha512', '$6$WeJknBPkDab')
-                    .should.equal('$6$WeJknBPkDab$yRRWg5Kr1MCAbKkBtKyKtldb9DFDXidKHj.wQwOKO1TSHUKCvIi7x9QubOenwGfYXoBK0vvwKvNgIlW9Oc6O4.'); //jshint ignore:line
+                    .should.equal('$6K02bHzduy/Y'); //jshint ignore:line
                 this.subject.createHash(data, 'sha256', '$5$WeJknBPkDab')
-                    .should.equal('$5$WeJknBPkDab$t4J3IF.tD9H/2HFDjV.CpFN1ay5rmwa7maVkstEiyv9');
+                    .should.equal('$5VQYaJCqoZho');
             });
         });
 


### PR DESCRIPTION
**Background**
----
Currently, unit test will fail in Nodejs 6 and Nodejs 8.
[https://rackhd.atlassian.net/browse/RAC-6232](https://rackhd.atlassian.net/browse/RAC-6232)

**AC**:
- Paired with @mcgG  
- Fix nodejs6 and nodejs8 unit test failures in local machine
- Don’t break nodejs 4 unit test
- Pilot run in travisci environment(don’t commit the fix, because further FIT test should pass before submitting


**Detail**
----
*case 1*
HttpTool Should handle basic auth:

- Cause:
Nock: No match for request GET http://mysite.emc.com/basicAuth

- Fix:
Upgrade nock from 3.5.0 to 9.0.22

*case 2*
Models.LocalUsers Password functions should serialize a password

- Error:
Uncaught TypeError: The "digest" argument is required and must not be undefined

- Cause:
built-in module crypto changes api "pbkdf2()" and "pbkdf2Sync()" in node8

- Fix:
```crypto.pbkdf2Sync(password, salt, iterations, hashBytes);```
change to
```crypto.pbkdf2Sync(password, salt, iterations, hashBytes,'sha512');``` 

```crypto.pbkdf2(obj.password, salt, hashConfig.iterations, hashConfig.hashBytes, function(err, hash)```
change to
```crypto.pbkdf2(obj.password, salt, hashConfig.iterations, hashConfig.hashBytes, "sha512", function(err, hash)```

*case 3*
should generate correct hash data

- Cause:
apache-crypt@1.0.9 return different value in Node 4 and 6

- Fix:
Upgrade apache-crypt from 1.0.9 to 1.2.1

File "spec/lib/common/encryption-spec.js"
```.should.equal('$6$WeJknBPkDab$yRRWg5Kr1MCAbKkBtKyKtldb9DFDXidKHj.wQwOKO1TSHUKCvIi7x9QubOenwGfYXoBK0vvwKvNgIlW9Oc6O4.');```
change to
```.should.equal('$6K02bHzduy/Y');```

```.should.equal('$5$WeJknBPkDab$t4J3IF.tD9H/2HFDjV.CpFN1ay5rmwa7maVkstEiyv9');```
change to
.should.equal('$5VQYaJCqoZho');

*case 4*
Failed to run ```npm test``` if use ```npm link``` to install modules.

- Cause:
supertest@0.15.0 doesn't support.end()

- Fix:
Upgrade supertest from 0.15.0 to 1.2.0

depends on: https://github.com/RackHD/on-tasks/pull/535
@anhou @iceiilin @mcgG @pengz1 