### PR TITLE
RAC-6432: failed to login os after upgrading module apache-crypt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM ${repo}/wheezy:${tag}
 COPY . /RackHD/on-core/
 
 RUN cd /RackHD/on-core \
-  && npm install --ignore-scripts --production
+  && npm install \
+  && npm prune --production
 
 VOLUME /opt/monorail

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function (di, directory) {
             helper.simpleWrapper(require('eventemitter2').EventEmitter2, 'EventEmitter'),
             helper.requireWrapper('shortid', 'shortid'),
             helper.requireWrapper('crypto', 'crypto'),
-            helper.requireWrapper('apache-crypt', 'apache-crypt'),
+            helper.requireWrapper('crypt3/sync', 'crypt'),
             helper.requireWrapper('util', 'util'),
             helper.requireWrapper('pluralize', 'pluralize'),
             helper.requireWrapper('always-tail', 'Tail'),

--- a/lib/common/encryption.js
+++ b/lib/common/encryption.js
@@ -8,7 +8,7 @@ encryptionFactory.$provide = 'Encryption';
 encryptionFactory.$inject = [
     'crypto',
     'Constants',
-    'apache-crypt'
+    'crypt'
 ];
 
 function encryptionFactory(
@@ -82,7 +82,7 @@ function encryptionFactory(
     };
 
     /**
-     * Create a salt to be used with crypt()
+     * Create a salt to be used with crypt().
      * @param {String} [algorithm='sha512'] - The hash algorithm, it should be one of
      * ['sha512', 'sha256','md5'], the default is 'sha512'
      * @param {String} [salt] - The salt feed to hash algorithm, if not specified, the function will
@@ -98,11 +98,16 @@ function encryptionFactory(
         if(!signatures[algorithm]) {
             throw new TypeError('Unknown salt algorithm: ' + algorithm);
         }
+
         if (salt && salt.charAt(0) === '$') {
-            salt = salt.split('$')[2];
+            salt = signatures[algorithm] + salt.split('$')[2];
+        } else if (salt) {
+            salt = signatures[algorithm] + salt;
+        } else{
+            salt = crypt.createSalt(algorithm);
         }
-        return signatures[algorithm] +
-            (salt || crypto.randomBytes(10).toString('base64'));
+        
+        return salt;
     };
 
     return Encryption;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "always-tail": "^0.2.0",
     "amqp": "0.2.3",
     "anchor": "^0.10.2",
-    "apache-crypt": "1.0.9",
+    "crypt3": "^1.0.0",
     "assert-plus": "^1.0.0",
     "bluebird": "^2.8.0",
     "bson": "~0.4.22",


### PR DESCRIPTION
The module apache-crypt@1.0.9 return different value in Node 4 and 6.
That leads to failure of unit test in node 6.

Fix:
Replace the module with crypt3@1.0.0

Test done:
Unit Test:
node 4: http://rackhdci.lss.emc.com/job/Archiving/job/tian/job/UnitTest_node4/109/
node 6: http://rackhdci.lss.emc.com/job/Archiving/job/tian/job/UnitTest_node6/134/
node 8 :http://rackhdci.lss.emc.com/job/Archiving/job/tian/job/UnitTest_node8/114/

Function Test:
Install ubuntu in quanta_d51 and succeed to login with user configured in payload.
Install centos 6.5 in quanta_d51 and succeed to login with user configured in payload.

@anhou @mcgg @iceiilin 
