### PR TITLE
Unit test fix for mocha update

### DIFF
--- a/spec/lib/common/child-process-spec.js
+++ b/spec/lib/common/child-process-spec.js
@@ -187,7 +187,7 @@ describe("ChildProcess", function () {
 
             // Use done() because if the promise is fulfilled that is a failure
             // case for this test. Assert that we hit this catch block.
-            return child.run()
+            child.run()
             .catch(function(e) {
                 expect(e).to.deep.equal(new Error('test failure'));
                 expect(_runSpy).to.have.been.calledOnce;
@@ -253,7 +253,7 @@ describe("ChildProcess", function () {
             execFileStub.returns(mockSpawnedProcess)
                 .callsArgWith(3, {code: -1}, undefined, "stderr result");
 
-            return child.run().then(function() {
+            child.run().then(function() {
                 done(new Error('Expect job to fail'));
             })
             .catch(function(e) {

--- a/spec/lib/common/connection-spec.js
+++ b/spec/lib/common/connection-spec.js
@@ -17,7 +17,7 @@ describe('Connection', function () {
         context.amqp = function() {
             this.createConnection = sandbox.stub();
         };
-        
+
         return [
             helper.di.simpleWrapper(context.Core, 'Services.Core' ),
             helper.di.simpleWrapper(context.amqp, 'amqp' )
@@ -28,7 +28,7 @@ describe('Connection', function () {
         Connection = helper.injector.get('Connection');
         amqp = helper.injector.get('amqp');
     });
-   
+
     beforeEach(function() {
         this.subject = new Connection({url: ''}, {}, 'test');
     });
@@ -288,7 +288,7 @@ describe('Connection', function () {
                             'disconnect':function(){done();},
                         });
                     });
-                    return this.subject.start().then(function () {
+                    this.subject.start().then(function () {
                         return expect(self.subject.stop()).to.be.fulfilled;
                     });
                 });

--- a/spec/lib/common/json-schema-validator-spec.js
+++ b/spec/lib/common/json-schema-validator-spec.js
@@ -342,7 +342,7 @@ describe('JsonSchemaValidator', function () {
             nodeFs.readFileAsync.onCall(0).resolves(JSON.stringify(testSchema1));
             nodeFs.readFileAsync.onCall(1).resolves(JSON.stringify(testRefSchema1));
 
-            return validator.addSchemasByDir('/testdir', 'noMetaSchema.json')
+            validator.addSchemasByDir('/testdir', 'noMetaSchema.json')
             .then(function () {
                 done(new Error("Expect addSchemasByDir to fail"));
             })
@@ -359,7 +359,7 @@ describe('JsonSchemaValidator', function () {
         });
 
         it('should throw assertion error when incorrect schemaDir passed', function (done) {
-            return validator.addSchemasByDir(123)
+            validator.addSchemasByDir(123)
             .then(function () {
                 done(new Error("Expect addSchemasByDir to fail"));
             })
@@ -376,7 +376,7 @@ describe('JsonSchemaValidator', function () {
         });
 
         it('should throw assertion error when incorrect metaSchemaName passed', function (done) {
-            return validator.addSchemasByDir('testdir3', 456)
+            validator.addSchemasByDir('testdir3', 456)
             .then(function () {
                 done(new Error("Expect addSchemasByDir to fail"));
             })

--- a/spec/lib/common/subscription-spec.js
+++ b/spec/lib/common/subscription-spec.js
@@ -88,7 +88,7 @@ describe('Subscription', function () {
             self.subject.MAX_DISPOSE_RETRIES = 1;
             self.queue.unsubscribe.rejects(new Error('test error'));
 
-            return expect(self.subject.dispose()).to.be.rejectedWith(/test error/)
+            expect(self.subject.dispose()).to.be.rejectedWith(/test error/)
             .then(function() {
                 setTimeout(function() {
                     try {
@@ -105,7 +105,7 @@ describe('Subscription', function () {
         });
 
         it('should reject with an error if the queue is already unsubscribed', function () {
-             
+
             this.subject.queue.state = 'closing';
 
             return this.subject.dispose().should.be.rejectedWith(

--- a/spec/lib/services/hook-spec.js
+++ b/spec/lib/services/hook-spec.js
@@ -13,7 +13,7 @@ describe('Hook', function () {
     var payload = {"hello": "world", "routingKey": "test"};
 
     helper.before();
-    
+
     before("Before hookService  test", function(){
         helper.setupInjector([
             helper.require('/lib/services/hook'),
@@ -52,7 +52,7 @@ describe('Hook', function () {
             .post('/test')
             .reply(201, 'OK');
         findStub.withArgs({}).resolves([hooks[0]]);
-        return hookService .publish(payload)
+        hookService .publish(payload)
         .then(function(){
             expect(hookService ._publish).to.have.been.calledOnce;
             expect(hookService ._publish).to.have.been.calledWith(hooks[0], payload);
@@ -80,7 +80,7 @@ describe('Hook', function () {
             .reply(201, 'OK');
 
         findStub.withArgs({}).resolves(hooks);
-        return hookService .publish(payload)
+        hookService .publish(payload)
         .then(function(){
             expect(hookService ._publish).to.have.been.calledTwice;
             expect(hookService ._publish).to.have.been.calledWith(hooks[0], payload);
@@ -97,7 +97,7 @@ describe('Hook', function () {
             expect(hookService ._publish).to.have.not.been.called;
         });
     });
-    
+
     it('should post data to hook url only after passed filter', function (done) {
         var _hooks = _.cloneDeep(hooks);
         var scope = nock('https://172.1.1.0:8080')
@@ -113,11 +113,11 @@ describe('Hook', function () {
             .reply(201, 'OK');
         _hooks[0].filters = [{hello: "world|anything"}, {routingKey: "anything"}];
         _hooks[1].filters = [
-            {hello: "world", routingKey: "anything"}, 
+            {hello: "world", routingKey: "anything"},
             {routingKey: "[^(anything|test)]"}
         ];
         findStub.withArgs({}).resolves(_hooks);
-        return hookService.publish(payload)
+        hookService.publish(payload)
         .then(function(){
             expect(hookService._publish).to.have.been.calledTwice;
             expect(scope.isDone()).to.equal(false);
@@ -138,7 +138,7 @@ describe('Hook', function () {
         _publishSpy.restore();
         sinon.stub(hookService , '_publish').withArgs(hooks[0], payload)
             .rejects(new Error('Failed to send data to all hooks'));
-        return hookService .publish(payload)
+        hookService .publish(payload)
         .then(function(){
             done(new Error('Test should fail'));
         })


### PR DESCRIPTION
RAC:  [https://rackhd.atlassian.net/browse/RAC-5743](https://rackhd.atlassian.net/browse/RAC-5743)
----
Paired with @PengTian0 

Using both `return promise` and `done()` in async unit test case will cause following error:
`Resolution method is overspecified. Specify a callback *or* return a Promise; not both.`

According to Mocha's [official site](http://mochajs.org/):
`In Mocha v3.0.0 and newer, returning a Promise and calling done() will result in an exception`

**Solution**
----
Only call done() instead of return a promise in all async unit test cases.


@PengTian0 @pengz1 @anhou @iceiilin @bbcyyb 