### PR TITLE
RAC-5743: unit test doesn't exit after upgrading mocha to 4.0.1

### DIFF
--- a/lib/common/connection.js
+++ b/lib/common/connection.js
@@ -102,7 +102,7 @@ function connectionFactory (assert, amqp, Promise, util, _) {
                     delete self.connection;
                     resolve();
                 });
-
+                self.connection.setImplOptions({reconnect: false});
                 self.connection.disconnect();
             } else {
                 reject(new Error('Connection Not Started.'));

--- a/lib/services/statsd.js
+++ b/lib/services/statsd.js
@@ -51,6 +51,7 @@ function statsdServiceFactory(
         if(this.started) {
             this.increment('process.stopped');
             this.started = false;
+            this.close();
         }
         return Promise.resolve();
     };

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "istanbul": "^0.3.5",
     "jsdoc": "^3.3.0-alpha13",
     "jshint": "^2.5.11",
-    "mocha": "^2.1.0",
+    "mocha": "^4.0.1",
     "nock": "~9.0.22",
     "sinon": "1.16.1",
     "sinon-as-promised": "^2.0.3",

--- a/spec/lib/common/connection-spec.js
+++ b/spec/lib/common/connection-spec.js
@@ -290,7 +290,8 @@ describe('Connection', function () {
                     });
                     this.subject.start().then(function () {
                         return expect(self.subject.stop()).to.be.fulfilled;
-                    });
+                    })
+                    .then(done());
                 });
 
                 it('should reject if not connected', function () {

--- a/spec/lib/protocol/dhcp-spec.js
+++ b/spec/lib/protocol/dhcp-spec.js
@@ -22,12 +22,10 @@ describe("DHCP protocol functions", function () {
         testSubscription = new Subscription({},{});
         testMessage = new Message({},{},{});
         sinon.stub(testMessage);
-        sinon.stub(messenger);
     });
     
     beforeEach(function() {
-        messenger.subscribe.reset();
-        messenger.request.reset();
+        this.sandbox.stub(messenger, 'request');
     });
  
     helper.after();
@@ -292,3 +290,4 @@ describe("DHCP protocol functions", function () {
         });
     });
 });
+

--- a/spec/lib/protocol/scheduler-spec.js
+++ b/spec/lib/protocol/scheduler-spec.js
@@ -20,7 +20,10 @@ describe("Schedular protocol functions", function () {
         testSubscription = new Subscription({},{});
         testMessage = new Message({},{},{});
         sinon.stub(testMessage);
-        sinon.stub(messenger);
+    });
+
+    beforeEach(function() {
+        this.sandbox.stub(messenger, 'request');
     });
 
     helper.after();

--- a/spec/lib/protocol/task-graph-runner-spec.js
+++ b/spec/lib/protocol/task-graph-runner-spec.js
@@ -25,7 +25,12 @@ describe("TaskGraph Runner protocol functions", function () {
         testSubscription = new Subscription({},{});
         testMessage = new Message({},{},{});
         sinon.stub(testMessage);
-        sinon.stub(messenger);
+    });
+
+    beforeEach(function() {
+        this.sandbox.stub(messenger, 'request');
+        this.sandbox.stub(messenger, 'publish');
+        this.sandbox.stub(messenger, 'subscribe');
     });
 
     helper.after();
@@ -88,6 +93,7 @@ describe("TaskGraph Runner protocol functions", function () {
 
         it("should subscribe and receive cancelTaskGraph failures", function() {
             var graphId = uuid.v4();
+            messenger.subscribe.restore();
             messenger.request.rejects(sampleError);
             return taskgraphrunner.subscribeCancelTaskGraph(function(_graphId) {
                 expect(_graphId).to.deep.equal(graphId);

--- a/spec/lib/protocol/task-spec.js
+++ b/spec/lib/protocol/task-spec.js
@@ -22,11 +22,14 @@ describe("Task protocol functions", function() {
         testSubscription = new Subscription({},{});
         testMessage = new Message({},{},{});
         sinon.stub(testMessage);
-        sinon.stub(messenger);
         sinon.stub(testSubscription);
         sinon.stub(events);
     });
 
+    beforeEach(function() {
+        this.sandbox.stub(messenger, 'request');
+        this.sandbox.stub(messenger, 'publish');
+    });
     helper.after();
 
     describe("Run", function() {

--- a/spec/lib/protocol/waterline-spec.js
+++ b/spec/lib/protocol/waterline-spec.js
@@ -17,23 +17,18 @@ describe('Protocol.Waterline', function() {
         var Subscription = helper.injector.get('Subscription');
         testSubscription = new Subscription({},{});
         sinon.stub(testSubscription);
-        sinon.stub(messenger);
     });
 
     helper.after();
 
     it('should publish a created event', function() {
-        messenger.publish.resolves();
         return waterlineProtocol.publishRecord(collection, 'created', { id: 1 });
     });
-
     it('should publish an updated event', function() {
-        messenger.publish.resolves();
         return waterlineProtocol.publishRecord(collection, 'updated', { id: 1 });
     });
 
     it('should publish a destroyed event', function() {     
-        messenger.publish.resolves();
         return waterlineProtocol.publishRecord(collection, 'destroyed', { id: 1 });
     });
 });


### PR DESCRIPTION
Paired with @mcgG 
Unit test doesn't exit after upgrading mocha to 4.0.1 because the new version of mocha won't exit if there are running process.
There are 3 kinds of cases that make mocha hangs
1. amqp: try to reconnect after disconnect(https://github.com/postwait/node-amqp/issues/462).
    Fix: set the option "reconnect" to false in stop() to avoid the issue.
2. statsd: the socket is not closed after call statsd.stop()
    Fix: call close() in stop() to close socket.
3. stub object messenger without restore. That leads to the messenger.stop() failed to stop amqp connection.
    Fix: replace stub object with stub method of object in beforeEach. The stubbed methods will be restored in afterEach().

@mcgG @anhou @pengz1 