### PR TITLE
WIP Adding redfish node for chassis/system combo

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -315,6 +315,14 @@ function constantsFactory (path) {
             containedBy: {
                 mapping: 'contains',
                 relationClass: 'link'
+            },
+            manages: {
+                mapping: 'managedBy',
+                relationClass: 'link'
+            },
+            managedBy: {
+                mapping: 'manages',
+                relationClass: 'link'
             }
         },
         Scope: {
@@ -332,7 +340,9 @@ function constantsFactory (path) {
             Storage: 'storage',
             Iom: 'iom',
             Cooling: 'cooling',
-            Power: 'power'
+            Power: 'power',
+            Redfish: 'redfish',
+            RedfishManager: 'redfishManager'
         },
         Redfish: {
             EventTypes: {

--- a/lib/common/errors.js
+++ b/lib/common/errors.js
@@ -81,6 +81,14 @@ function ErrorFactory(util) {
     }
     util.inherits(ConflictError, BaseError);
 
+    function NotImplementedError(message, context) {
+        BaseError.call(this, message, context);
+        Error.captureStackTrace(this, NotImplementedError);
+        this.status = 501;
+    }
+    util.inherits(NotImplementedError, BaseError);
+
+
     function RequestTimedOutError(message) {
         BaseError.call(this, message);
         Error.captureStackTrace(this, RequestTimedOutError);
@@ -176,6 +184,7 @@ function ErrorFactory(util) {
         ViewRenderError: ViewRenderError,
         BreakPromiseChainError: BreakPromiseChainError,
         JobKilledError: JobKilledError,
-        MaxGraphsRunningError: MaxGraphsRunningError
+        MaxGraphsRunningError: MaxGraphsRunningError,
+        NotImplementedError: NotImplementedError
     };
 }

--- a/spec/lib/common/errors-spec.js
+++ b/spec/lib/common/errors-spec.js
@@ -216,4 +216,38 @@ describe("Errors", function() {
             this.subject.stack.split('\n')[1].should.contain(__filename);
         });
     });
+
+    describe('NotImplementedError', function () {
+        before(function () {
+            this.subject = new Errors.NotImplementedError('message');
+        });
+
+        it('should be an instance of Error', function () {
+            this.subject.should.be.an.instanceof(Error);
+        });
+
+        it('should be an instance of BaseError', function () {
+            this.subject.should.be.an.instanceof(Errors.BaseError);
+        });
+
+        it('should be an instance of NotImplementedError', function () {
+            this.subject.should.be.an.instanceof(Errors.NotImplementedError);
+        });
+
+        it('should have a name of NotImplementedError', function () {
+            this.subject.name.should.be.equal('NotImplementedError');
+        });
+
+        it('should have a message of message', function () {
+            this.subject.message.should.be.equal('message');
+        });
+
+        it('should provide the correct stack trace', function () {
+            this.subject.stack.split('\n')[1].should.contain(__filename);
+        });
+
+        it('should provide a 400 status', function () {
+            this.subject.status.should.equal(501);
+        });
+    });
 });


### PR DESCRIPTION
Adding Redfish manager node type and adding a Defined Error for 501 Not Implemented

adding spec tests

************
Part of Changes in on-core, on-http, on-tasks, on-taskgraph


The combination of these changes is to fully implement redfish device discovery. This includes the fillowing items:

1) The implementation of unique device identifiers in place of the RackHD GUID identifers.
    a) These ids provide the user the ability to know which node they are looking at. This is usefull for
       aggregation.
    b) All RackHD Redfish calls can use either the new id or the original RackHD GUID. The RackHD api still can
       only use the GUID.
    c) Currently this id is made with a combination of the serial number and sku from the redfish discovery.
2) Creation of redfish and redfishManager node types.
    a) redfish nodes are combination of systems and chassis in one node. This is because some redfish implementations
       report system and chassis as one object.
    b) redfishManagers are a node object to store information about the managers discovered durring redfish discovery.
    c) Maintains support with /Chassis /Systems and /Managers Redfish calls.
3) Dynamic modification of redfish catalogs.
    a) injection of the unique device id into the discovered redfish catalogs.
    b) catalog names and id use the unique device id.
    c) stored in only the relavent node with the source as the odata.id of the call that got the info.
       ie. /Systems/{identifier}/...
4) Implemented support for redfish discovered devices in the redfish API (GET, PATCH, and POST).
    a) GETs returned the stored catalogs from discovery
    b) PUTs and POSTs start a wrokflow that does the Redfish call on the discovered device with the provide payload
5) Modified spec test to support redfish devices.
    a) Changed from nodeApi stubbing to waterline stubbing in system and chassis spec tests.
6) Implementation of general purpose REST API workflow.
    a) Currently used for doing redfish calls but can be run with any REST calls.
7) RackHD Redfish API only works for calls which the device '@odata.id's match the RackHD Redfish implementation
    a) not all devices follow this implementation due to the opaque nature of the Redfish odata links
    b) To support all would require work to interpret all data during discovery and dynamically store it.

Reddish Discovery allows for the aggregation of Redfish complaint devices. The discovery creates node objects for compute, enclosure, redfish, and redfishManager nodes. The redfish nodes are a combination of a system and chassis and the redfishManager is for storing the manager objects discovered.