### PR TITLE
[RAC-6701] Fix NPM5 build dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-# Copyright 2016, EMC, Inc. 
-ARG repo=nodesource
-ARG tag=4.4.6
+# Copyright 2016, EMC, Inc.
+ARG repo=node
+ARG tag=8.11.1
 
-FROM ${repo}/wheezy:${tag}
+FROM ${repo}:${tag}
 
 COPY . /RackHD/on-core/
 
 RUN cd /RackHD/on-core \
-  && npm install \
-  && npm prune --production
+  && npm install --production
 
 VOLUME /opt/monorail


### PR DESCRIPTION
**Background**
https://rackhd.atlassian.net/browse/RAC-6701
This story is aimed to update node dependency to the version of 8.x in pipelines. However, NPM 5.x (lower than 5.7.1) within node 8.x environment has an issue while building dependencies for docker image, that is it would remove dependencies built from web URL (git repo in our case).

**Details**
As a workaround, build back the dependencies from web URL after dependency removed.
Besides, change node base image repo, from nodesource/wheezy to node

**Dependencies**
depends on:RackHD/on-tasks#590 https://github.com/RackHD/on-taskgraph/pull/375 https://github.com/RackHD/on-http/pull/834 https://github.com/RackHD/on-dhcp-proxy/pull/88 https://github.com/RackHD/on-syslog/pull/53 https://github.com/RackHD/on-tftp/pull/79

