### PR TITLE
fix "Cannot assign to read only property '0' of string 'Task.Add.Hotspare'"

### DIFF
--- a/lib/serializables/log-event.js
+++ b/lib/serializables/log-event.js
@@ -193,14 +193,8 @@ function LogEventFactory (
                 accumulator[key] = value;
             }
 
-            if (_.isObject(accumulator[key])) {
+            if (_.isObject(accumulator[key]) || _.isArray(accumulator[key])) {
                 accumulator[key] = LogEvent._redact(accumulator[key]);
-            }
-
-            if (_.isArray(accumulator[key])) {
-                accumulator[key] = _.map(accumulator[key], function (item) {
-                    return LogEvent._redact(item);
-                });
             }
         }, target || {});
     };

--- a/spec/lib/serializables/log-event-spec.js
+++ b/spec/lib/serializables/log-event-spec.js
@@ -67,6 +67,11 @@ describe('LogEvent', function () {
                 });
             });
 
+            it('should succeed if the field is a string array', function() {
+                var srcObj = { array: [ {'bar': ['foo']} ] };
+                LogEvent.redact(srcObj).should.deep.equal(srcObj);
+            });
+
             it('should redact fields which are marked for redaction', function() {
                 _.forEach(testRedactKeys, function(key) {
                     var srcObj = {}, dstObj = {};


### PR DESCRIPTION
**Issue:**
Cannot assign to read only property '0' of string 'Task.Add.Hotspare'

https://rackhd.atlassian.net/browse/RAC-6774

**Root Cause:**
After upgrading node from v4 to v8, the property '0' of string turned
out read-only.

**Done:**
* Refine the code to avoid assigning to read only property of string. Only when the target is an array or object, we will recursively call the `_redact` function.
* Add unit test


@RackHD/corecommitters @nortonluo @iceiilin 