### PR TITLE
[RAC-6786]Modify macAddress to lower case before writing to DB

### DIFF
--- a/lib/models/lookup.js
+++ b/lib/models/lookup.js
@@ -95,6 +95,7 @@ function LookupModelFactory (
             assert.string(node, 'node');
             assert.string(macAddress, 'macAddress');
 
+            macAddress = macAddress.toLowerCase();
             var query = { macAddress: macAddress };
             var options = {
                 new: true,
@@ -129,6 +130,7 @@ function LookupModelFactory (
 
             var self = this;
 
+            macAddress = macAddress.toLowerCase();
             return self.findOne({ macAddress: macAddress }).then(function (record) {
                 if (record) {
                     return self.update(
@@ -145,6 +147,7 @@ function LookupModelFactory (
             });
         },
         setIp: function(ipAddress, macAddress) {
+            macAddress = macAddress.toLowerCase();
             switch(dbType) {
                 case 'mongo':
                     return this.setIpMongo(ipAddress, macAddress);

--- a/spec/lib/models/lookup-spec.js
+++ b/spec/lib/models/lookup-spec.js
@@ -186,7 +186,7 @@ describe('Models.Lookup', function () {
                     'macAddress'
                 ).then(function () {
                     expect(waterline.lookups.findAndModifyMongo).to.have.been.calledOnce;
-                    var query = { macAddress: 'macAddress' };
+                    var query = { macAddress: 'macaddress' };
                     var update = { $set: { node:  waterline.lookups.mongo.objectId('node') }};
                     expect(waterline.lookups.findAndModifyMongo.firstCall.args[0])
                         .to.deep.equal(query);
@@ -212,7 +212,7 @@ describe('Models.Lookup', function () {
                     'proxy',
                     'macAddress'
                 ).then(function () {
-                    expect(findOne).to.have.been.calledWith({ macAddress: 'macAddress' });
+                    expect(findOne).to.have.been.calledWith({ macAddress: 'macaddress' });
                     expect(update).to.have.been.calledWith({ id: 'id' }, { proxy: 'proxy' });
                 });
             });
@@ -224,7 +224,7 @@ describe('Models.Lookup', function () {
                     'proxy',
                     'macAddress'
                 )).to.be.rejectedWith(Errors.NotFoundError).then(function () {
-                    expect(findOne).to.have.been.calledWith({ macAddress: 'macAddress' });
+                    expect(findOne).to.have.been.calledWith({ macAddress: 'macaddress' });
                 });
             });
         });


### PR DESCRIPTION
A bug is reported about upper cases of MAC Address in lookups collection but cannot be queried. The reason is in on-core, we change the query to lower case before searching in mongoDB.

MAC Address can be either upper or lower case, but data in MongoDB is case sensitive, and insensitive operations could not leverage index and slow down the response. So modifying MAC address to lower case before updating documents, which is align with common practice in *nix such as dhcpd.